### PR TITLE
feat: Implement subscription, add firehose examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,6 @@ members = [
     "atrium-codegen",
     "atrium-lex",
     "atrium-xrpc",
+    "atrium-xrpc-server",
     "examples/firehose",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,5 @@ members = [
     "atrium-codegen",
     "atrium-lex",
     "atrium-xrpc",
+    "examples/firehose",
 ]

--- a/atrium-api/Cargo.toml
+++ b/atrium-api/Cargo.toml
@@ -13,8 +13,10 @@ keywords = ["atproto", "bluesky"]
 
 [dependencies]
 async-trait = "0.1.68"
+cid = { version = "0.10.1", features = ["serde-codec"] }
 http = "0.2.9"
 serde = { version = "1.0.160", features = ["derive"] }
+serde_bytes = "0.11.9"
 serde_json = "1.0.96"
 serde_urlencoded = "0.7.1"
 

--- a/atrium-api/src/app/bsky/actor/defs.rs
+++ b/atrium-api/src/app/bsky/actor/defs.rs
@@ -15,7 +15,7 @@ pub struct ContentLabelPref {
     pub visibility: String,
 }
 #[doc = "`app.bsky.actor.defs#preferences`"]
-pub type Preferences = Vec<Box<PreferencesItem>>;
+pub type Preferences = Vec<PreferencesItem>;
 #[doc = "`app.bsky.actor.defs#profileView`"]
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -98,7 +98,7 @@ pub struct ViewerState {
 #[serde(tag = "$type")]
 pub enum PreferencesItem {
     #[serde(rename = "app.bsky.actor.defs#adultContentPref")]
-    AdultContentPref(AdultContentPref),
+    AdultContentPref(Box<AdultContentPref>),
     #[serde(rename = "app.bsky.actor.defs#contentLabelPref")]
-    ContentLabelPref(ContentLabelPref),
+    ContentLabelPref(Box<ContentLabelPref>),
 }

--- a/atrium-api/src/app/bsky/embed/record.rs
+++ b/atrium-api/src/app/bsky/embed/record.rs
@@ -11,7 +11,7 @@ pub struct Main {
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct View {
-    pub record: Box<ViewRecordEnum>,
+    pub record: ViewRecordEnum,
 }
 #[doc = "`app.bsky.embed.record#viewBlocked`"]
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -32,7 +32,7 @@ pub struct ViewRecord {
     pub author: crate::app::bsky::actor::defs::ProfileViewBasic,
     pub cid: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub embeds: Option<Vec<Box<ViewRecordEmbedsItem>>>,
+    pub embeds: Option<Vec<ViewRecordEmbedsItem>>,
     pub indexed_at: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<Vec<crate::com::atproto::label::defs::Label>>,
@@ -43,21 +43,21 @@ pub struct ViewRecord {
 #[serde(tag = "$type")]
 pub enum ViewRecordEmbedsItem {
     #[serde(rename = "app.bsky.embed.images#view")]
-    AppBskyEmbedImagesView(crate::app::bsky::embed::images::View),
+    AppBskyEmbedImagesView(Box<crate::app::bsky::embed::images::View>),
     #[serde(rename = "app.bsky.embed.external#view")]
-    AppBskyEmbedExternalView(crate::app::bsky::embed::external::View),
+    AppBskyEmbedExternalView(Box<crate::app::bsky::embed::external::View>),
     #[serde(rename = "app.bsky.embed.record#view")]
-    AppBskyEmbedRecordView(crate::app::bsky::embed::record::View),
+    AppBskyEmbedRecordView(Box<crate::app::bsky::embed::record::View>),
     #[serde(rename = "app.bsky.embed.recordWithMedia#view")]
-    AppBskyEmbedRecordWithMediaView(crate::app::bsky::embed::record_with_media::View),
+    AppBskyEmbedRecordWithMediaView(Box<crate::app::bsky::embed::record_with_media::View>),
 }
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "$type")]
 pub enum ViewRecordEnum {
     #[serde(rename = "app.bsky.embed.record#viewRecord")]
-    ViewRecord(ViewRecord),
+    ViewRecord(Box<ViewRecord>),
     #[serde(rename = "app.bsky.embed.record#viewNotFound")]
-    ViewNotFound(ViewNotFound),
+    ViewNotFound(Box<ViewNotFound>),
     #[serde(rename = "app.bsky.embed.record#viewBlocked")]
-    ViewBlocked(ViewBlocked),
+    ViewBlocked(Box<ViewBlocked>),
 }

--- a/atrium-api/src/app/bsky/embed/record_with_media.rs
+++ b/atrium-api/src/app/bsky/embed/record_with_media.rs
@@ -5,29 +5,29 @@
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Main {
-    pub media: Box<MainMediaEnum>,
+    pub media: MainMediaEnum,
     pub record: crate::app::bsky::embed::record::Main,
 }
 #[doc = "`app.bsky.embed.recordWithMedia#view`"]
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct View {
-    pub media: Box<ViewMediaEnum>,
+    pub media: ViewMediaEnum,
     pub record: crate::app::bsky::embed::record::View,
 }
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "$type")]
 pub enum MainMediaEnum {
     #[serde(rename = "app.bsky.embed.images")]
-    AppBskyEmbedImagesMain(crate::app::bsky::embed::images::Main),
+    AppBskyEmbedImagesMain(Box<crate::app::bsky::embed::images::Main>),
     #[serde(rename = "app.bsky.embed.external")]
-    AppBskyEmbedExternalMain(crate::app::bsky::embed::external::Main),
+    AppBskyEmbedExternalMain(Box<crate::app::bsky::embed::external::Main>),
 }
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "$type")]
 pub enum ViewMediaEnum {
     #[serde(rename = "app.bsky.embed.images#view")]
-    AppBskyEmbedImagesView(crate::app::bsky::embed::images::View),
+    AppBskyEmbedImagesView(Box<crate::app::bsky::embed::images::View>),
     #[serde(rename = "app.bsky.embed.external#view")]
-    AppBskyEmbedExternalView(crate::app::bsky::embed::external::View),
+    AppBskyEmbedExternalView(Box<crate::app::bsky::embed::external::View>),
 }

--- a/atrium-api/src/app/bsky/feed/defs.rs
+++ b/atrium-api/src/app/bsky/feed/defs.rs
@@ -13,7 +13,7 @@ pub struct BlockedPost {
 pub struct FeedViewPost {
     pub post: crate::app::bsky::feed::defs::PostView,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reason: Option<Box<FeedViewPostReasonEnum>>,
+    pub reason: Option<FeedViewPostReasonEnum>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reply: Option<ReplyRef>,
 }
@@ -31,7 +31,7 @@ pub struct PostView {
     pub author: crate::app::bsky::actor::defs::ProfileViewBasic,
     pub cid: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub embed: Option<Box<PostViewEmbedEnum>>,
+    pub embed: Option<PostViewEmbedEnum>,
     pub indexed_at: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<Vec<crate::com::atproto::label::defs::Label>>,
@@ -65,10 +65,10 @@ pub struct ReplyRef {
 #[serde(rename_all = "camelCase")]
 pub struct ThreadViewPost {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub parent: Option<Box<ThreadViewPostParentEnum>>,
+    pub parent: Option<ThreadViewPostParentEnum>,
     pub post: PostView,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub replies: Option<Vec<Box<ThreadViewPostRepliesItem>>>,
+    pub replies: Option<Vec<ThreadViewPostRepliesItem>>,
 }
 #[doc = "`app.bsky.feed.defs#viewerState`"]
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -83,37 +83,37 @@ pub struct ViewerState {
 #[serde(tag = "$type")]
 pub enum FeedViewPostReasonEnum {
     #[serde(rename = "app.bsky.feed.defs#reasonRepost")]
-    ReasonRepost(ReasonRepost),
+    ReasonRepost(Box<ReasonRepost>),
 }
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "$type")]
 pub enum PostViewEmbedEnum {
     #[serde(rename = "app.bsky.embed.images#view")]
-    AppBskyEmbedImagesView(crate::app::bsky::embed::images::View),
+    AppBskyEmbedImagesView(Box<crate::app::bsky::embed::images::View>),
     #[serde(rename = "app.bsky.embed.external#view")]
-    AppBskyEmbedExternalView(crate::app::bsky::embed::external::View),
+    AppBskyEmbedExternalView(Box<crate::app::bsky::embed::external::View>),
     #[serde(rename = "app.bsky.embed.record#view")]
-    AppBskyEmbedRecordView(crate::app::bsky::embed::record::View),
+    AppBskyEmbedRecordView(Box<crate::app::bsky::embed::record::View>),
     #[serde(rename = "app.bsky.embed.recordWithMedia#view")]
-    AppBskyEmbedRecordWithMediaView(crate::app::bsky::embed::record_with_media::View),
+    AppBskyEmbedRecordWithMediaView(Box<crate::app::bsky::embed::record_with_media::View>),
 }
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "$type")]
 pub enum ThreadViewPostParentEnum {
     #[serde(rename = "app.bsky.feed.defs#threadViewPost")]
-    ThreadViewPost(ThreadViewPost),
+    ThreadViewPost(Box<ThreadViewPost>),
     #[serde(rename = "app.bsky.feed.defs#notFoundPost")]
-    NotFoundPost(NotFoundPost),
+    NotFoundPost(Box<NotFoundPost>),
     #[serde(rename = "app.bsky.feed.defs#blockedPost")]
-    BlockedPost(BlockedPost),
+    BlockedPost(Box<BlockedPost>),
 }
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "$type")]
 pub enum ThreadViewPostRepliesItem {
     #[serde(rename = "app.bsky.feed.defs#threadViewPost")]
-    ThreadViewPost(ThreadViewPost),
+    ThreadViewPost(Box<ThreadViewPost>),
     #[serde(rename = "app.bsky.feed.defs#notFoundPost")]
-    NotFoundPost(NotFoundPost),
+    NotFoundPost(Box<NotFoundPost>),
     #[serde(rename = "app.bsky.feed.defs#blockedPost")]
-    BlockedPost(BlockedPost),
+    BlockedPost(Box<BlockedPost>),
 }

--- a/atrium-api/src/app/bsky/feed/get_post_thread.rs
+++ b/atrium-api/src/app/bsky/feed/get_post_thread.rs
@@ -29,7 +29,7 @@ pub struct Parameters {
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Output {
-    pub thread: Box<OutputThreadEnum>,
+    pub thread: OutputThreadEnum,
 }
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
@@ -40,9 +40,9 @@ pub enum Error {
 #[serde(tag = "$type")]
 pub enum OutputThreadEnum {
     #[serde(rename = "app.bsky.feed.defs#threadViewPost")]
-    AppBskyFeedDefsThreadViewPost(crate::app::bsky::feed::defs::ThreadViewPost),
+    AppBskyFeedDefsThreadViewPost(Box<crate::app::bsky::feed::defs::ThreadViewPost>),
     #[serde(rename = "app.bsky.feed.defs#notFoundPost")]
-    AppBskyFeedDefsNotFoundPost(crate::app::bsky::feed::defs::NotFoundPost),
+    AppBskyFeedDefsNotFoundPost(Box<crate::app::bsky::feed::defs::NotFoundPost>),
     #[serde(rename = "app.bsky.feed.defs#blockedPost")]
-    AppBskyFeedDefsBlockedPost(crate::app::bsky::feed::defs::BlockedPost),
+    AppBskyFeedDefsBlockedPost(Box<crate::app::bsky::feed::defs::BlockedPost>),
 }

--- a/atrium-api/src/app/bsky/feed/post.rs
+++ b/atrium-api/src/app/bsky/feed/post.rs
@@ -6,7 +6,7 @@
 pub struct Record {
     pub created_at: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub embed: Option<Box<RecordEmbedEnum>>,
+    pub embed: Option<RecordEmbedEnum>,
     #[doc = "Deprecated: replaced by app.bsky.richtext.facet."]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub entities: Option<Vec<Entity>>,
@@ -45,11 +45,11 @@ pub struct TextSlice {
 #[serde(tag = "$type")]
 pub enum RecordEmbedEnum {
     #[serde(rename = "app.bsky.embed.images")]
-    AppBskyEmbedImagesMain(crate::app::bsky::embed::images::Main),
+    AppBskyEmbedImagesMain(Box<crate::app::bsky::embed::images::Main>),
     #[serde(rename = "app.bsky.embed.external")]
-    AppBskyEmbedExternalMain(crate::app::bsky::embed::external::Main),
+    AppBskyEmbedExternalMain(Box<crate::app::bsky::embed::external::Main>),
     #[serde(rename = "app.bsky.embed.record")]
-    AppBskyEmbedRecordMain(crate::app::bsky::embed::record::Main),
+    AppBskyEmbedRecordMain(Box<crate::app::bsky::embed::record::Main>),
     #[serde(rename = "app.bsky.embed.recordWithMedia")]
-    AppBskyEmbedRecordWithMediaMain(crate::app::bsky::embed::record_with_media::Main),
+    AppBskyEmbedRecordWithMediaMain(Box<crate::app::bsky::embed::record_with_media::Main>),
 }

--- a/atrium-api/src/app/bsky/richtext/facet.rs
+++ b/atrium-api/src/app/bsky/richtext/facet.rs
@@ -4,7 +4,7 @@
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Main {
-    pub features: Vec<Box<MainFeaturesItem>>,
+    pub features: Vec<MainFeaturesItem>,
     pub index: ByteSlice,
 }
 #[doc = "`app.bsky.richtext.facet#byteSlice`"]
@@ -33,7 +33,7 @@ pub struct Mention {
 #[serde(tag = "$type")]
 pub enum MainFeaturesItem {
     #[serde(rename = "app.bsky.richtext.facet#mention")]
-    Mention(Mention),
+    Mention(Box<Mention>),
     #[serde(rename = "app.bsky.richtext.facet#link")]
-    Link(Link),
+    Link(Box<Link>),
 }

--- a/atrium-api/src/com/atproto/admin/defs.rs
+++ b/atrium-api/src/com/atproto/admin/defs.rs
@@ -29,7 +29,7 @@ pub struct ActionView {
     pub resolved_report_ids: Vec<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reversal: Option<ActionReversal>,
-    pub subject: Box<ActionViewSubjectEnum>,
+    pub subject: ActionViewSubjectEnum,
     pub subject_blob_cids: Vec<String>,
 }
 #[doc = "`com.atproto.admin.defs#actionViewCurrent`"]
@@ -55,7 +55,7 @@ pub struct ActionViewDetail {
     pub resolved_reports: Vec<ReportView>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reversal: Option<ActionReversal>,
-    pub subject: Box<ActionViewDetailSubjectEnum>,
+    pub subject: ActionViewDetailSubjectEnum,
     pub subject_blobs: Vec<BlobView>,
 }
 #[doc = "`com.atproto.admin.defs#blobView`"]
@@ -65,7 +65,7 @@ pub struct BlobView {
     pub cid: String,
     pub created_at: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub details: Option<Box<BlobViewDetailsEnum>>,
+    pub details: Option<BlobViewDetailsEnum>,
     pub mime_type: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub moderation: Option<Moderation>,
@@ -179,7 +179,7 @@ pub struct ReportView {
     pub reason_type: crate::com::atproto::moderation::defs::ReasonType,
     pub reported_by: String,
     pub resolved_by_action_ids: Vec<i32>,
-    pub subject: Box<ReportViewSubjectEnum>,
+    pub subject: ReportViewSubjectEnum,
 }
 #[doc = "`com.atproto.admin.defs#reportViewDetail`"]
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -192,7 +192,7 @@ pub struct ReportViewDetail {
     pub reason_type: crate::com::atproto::moderation::defs::ReasonType,
     pub reported_by: String,
     pub resolved_by_actions: Vec<crate::com::atproto::admin::defs::ActionView>,
-    pub subject: Box<ReportViewDetailSubjectEnum>,
+    pub subject: ReportViewDetailSubjectEnum,
 }
 #[doc = "`com.atproto.admin.defs#takedown`"]
 #[doc = "Moderation action type: Takedown. Indicates that content should not be served by the PDS."]
@@ -209,39 +209,39 @@ pub struct VideoDetails {
 #[serde(tag = "$type")]
 pub enum ActionViewDetailSubjectEnum {
     #[serde(rename = "com.atproto.admin.defs#repoView")]
-    RepoView(RepoView),
+    RepoView(Box<RepoView>),
     #[serde(rename = "com.atproto.admin.defs#recordView")]
-    RecordView(RecordView),
+    RecordView(Box<RecordView>),
 }
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "$type")]
 pub enum ActionViewSubjectEnum {
     #[serde(rename = "com.atproto.admin.defs#repoRef")]
-    RepoRef(RepoRef),
+    RepoRef(Box<RepoRef>),
     #[serde(rename = "com.atproto.repo.strongRef")]
-    ComAtprotoRepoStrongRefMain(crate::com::atproto::repo::strong_ref::Main),
+    ComAtprotoRepoStrongRefMain(Box<crate::com::atproto::repo::strong_ref::Main>),
 }
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "$type")]
 pub enum BlobViewDetailsEnum {
     #[serde(rename = "com.atproto.admin.defs#imageDetails")]
-    ImageDetails(ImageDetails),
+    ImageDetails(Box<ImageDetails>),
     #[serde(rename = "com.atproto.admin.defs#videoDetails")]
-    VideoDetails(VideoDetails),
+    VideoDetails(Box<VideoDetails>),
 }
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "$type")]
 pub enum ReportViewDetailSubjectEnum {
     #[serde(rename = "com.atproto.admin.defs#repoView")]
-    RepoView(RepoView),
+    RepoView(Box<RepoView>),
     #[serde(rename = "com.atproto.admin.defs#recordView")]
-    RecordView(RecordView),
+    RecordView(Box<RecordView>),
 }
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "$type")]
 pub enum ReportViewSubjectEnum {
     #[serde(rename = "com.atproto.admin.defs#repoRef")]
-    RepoRef(RepoRef),
+    RepoRef(Box<RepoRef>),
     #[serde(rename = "com.atproto.repo.strongRef")]
-    ComAtprotoRepoStrongRefMain(crate::com::atproto::repo::strong_ref::Main),
+    ComAtprotoRepoStrongRefMain(Box<crate::com::atproto::repo::strong_ref::Main>),
 }

--- a/atrium-api/src/com/atproto/admin/take_moderation_action.rs
+++ b/atrium-api/src/com/atproto/admin/take_moderation_action.rs
@@ -30,7 +30,7 @@ pub struct Input {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub negate_label_vals: Option<Vec<String>>,
     pub reason: String,
-    pub subject: Box<InputSubjectEnum>,
+    pub subject: InputSubjectEnum,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subject_blob_cids: Option<Vec<String>>,
 }
@@ -44,7 +44,7 @@ pub enum Error {
 #[serde(tag = "$type")]
 pub enum InputSubjectEnum {
     #[serde(rename = "com.atproto.admin.defs#repoRef")]
-    ComAtprotoAdminDefsRepoRef(crate::com::atproto::admin::defs::RepoRef),
+    ComAtprotoAdminDefsRepoRef(Box<crate::com::atproto::admin::defs::RepoRef>),
     #[serde(rename = "com.atproto.repo.strongRef")]
-    ComAtprotoRepoStrongRefMain(crate::com::atproto::repo::strong_ref::Main),
+    ComAtprotoRepoStrongRefMain(Box<crate::com::atproto::repo::strong_ref::Main>),
 }

--- a/atrium-api/src/com/atproto/label/subscribe_labels.rs
+++ b/atrium-api/src/com/atproto/label/subscribe_labels.rs
@@ -18,3 +18,11 @@ pub struct Labels {
     pub labels: Vec<crate::com::atproto::label::defs::Label>,
     pub seq: i32,
 }
+#[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "$type")]
+pub enum Message {
+    #[serde(rename = "com.atproto.label.subscribeLabels#labels")]
+    Labels(Box<Labels>),
+    #[serde(rename = "com.atproto.label.subscribeLabels#info")]
+    Info(Box<Info>),
+}

--- a/atrium-api/src/com/atproto/moderation/create_report.rs
+++ b/atrium-api/src/com/atproto/moderation/create_report.rs
@@ -23,7 +23,7 @@ pub struct Input {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
     pub reason_type: crate::com::atproto::moderation::defs::ReasonType,
-    pub subject: Box<InputSubjectEnum>,
+    pub subject: InputSubjectEnum,
 }
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -34,7 +34,7 @@ pub struct Output {
     pub reason: Option<String>,
     pub reason_type: crate::com::atproto::moderation::defs::ReasonType,
     pub reported_by: String,
-    pub subject: Box<OutputSubjectEnum>,
+    pub subject: OutputSubjectEnum,
 }
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
@@ -43,15 +43,15 @@ pub enum Error {}
 #[serde(tag = "$type")]
 pub enum InputSubjectEnum {
     #[serde(rename = "com.atproto.admin.defs#repoRef")]
-    ComAtprotoAdminDefsRepoRef(crate::com::atproto::admin::defs::RepoRef),
+    ComAtprotoAdminDefsRepoRef(Box<crate::com::atproto::admin::defs::RepoRef>),
     #[serde(rename = "com.atproto.repo.strongRef")]
-    ComAtprotoRepoStrongRefMain(crate::com::atproto::repo::strong_ref::Main),
+    ComAtprotoRepoStrongRefMain(Box<crate::com::atproto::repo::strong_ref::Main>),
 }
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "$type")]
 pub enum OutputSubjectEnum {
     #[serde(rename = "com.atproto.admin.defs#repoRef")]
-    ComAtprotoAdminDefsRepoRef(crate::com::atproto::admin::defs::RepoRef),
+    ComAtprotoAdminDefsRepoRef(Box<crate::com::atproto::admin::defs::RepoRef>),
     #[serde(rename = "com.atproto.repo.strongRef")]
-    ComAtprotoRepoStrongRefMain(crate::com::atproto::repo::strong_ref::Main),
+    ComAtprotoRepoStrongRefMain(Box<crate::com::atproto::repo::strong_ref::Main>),
 }

--- a/atrium-api/src/com/atproto/repo/apply_writes.rs
+++ b/atrium-api/src/com/atproto/repo/apply_writes.rs
@@ -27,7 +27,7 @@ pub struct Input {
     #[doc = "Validate the records?"]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub validate: Option<bool>,
-    pub writes: Vec<Box<InputWritesItem>>,
+    pub writes: Vec<InputWritesItem>,
 }
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
@@ -65,9 +65,9 @@ pub struct Update {
 #[serde(tag = "$type")]
 pub enum InputWritesItem {
     #[serde(rename = "com.atproto.repo.applyWrites#create")]
-    Create(Create),
+    Create(Box<Create>),
     #[serde(rename = "com.atproto.repo.applyWrites#update")]
-    Update(Update),
+    Update(Box<Update>),
     #[serde(rename = "com.atproto.repo.applyWrites#delete")]
-    Delete(Delete),
+    Delete(Box<Delete>),
 }

--- a/atrium-api/src/com/atproto/sync/subscribe_repos.rs
+++ b/atrium-api/src/com/atproto/sync/subscribe_repos.rs
@@ -14,7 +14,7 @@ pub struct Commit {
     pub time: String,
     pub too_big: bool,
     pub commit: cid::Cid,
-    pub prev: cid::Cid,
+    pub prev: Option<cid::Cid>,
     pub blobs: Vec<cid::Cid>,
     #[serde(with = "serde_bytes")]
     pub blocks: Vec<u8>,

--- a/atrium-api/src/com/atproto/sync/subscribe_repos.rs
+++ b/atrium-api/src/com/atproto/sync/subscribe_repos.rs
@@ -7,17 +7,19 @@ pub struct SubscribeRepos;
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Commit {
+    pub blobs: Vec<cid::Cid>,
+    #[doc = "CAR file containing relevant blocks"]
+    #[serde(with = "serde_bytes")]
+    pub blocks: Vec<u8>,
+    pub commit: cid::Cid,
     pub ops: Vec<RepoOp>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prev: Option<cid::Cid>,
     pub rebase: bool,
     pub repo: String,
     pub seq: i32,
     pub time: String,
     pub too_big: bool,
-    pub commit: cid::Cid,
-    pub prev: Option<cid::Cid>,
-    pub blobs: Vec<cid::Cid>,
-    #[serde(with = "serde_bytes")]
-    pub blocks: Vec<u8>,
 }
 #[doc = "`com.atproto.sync.subscribeRepos#handle`"]
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -41,7 +43,8 @@ pub struct Info {
 #[serde(rename_all = "camelCase")]
 pub struct Migrate {
     pub did: String,
-    pub migrate_to: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub migrate_to: Option<String>,
     pub seq: i32,
     pub time: String,
 }
@@ -50,8 +53,9 @@ pub struct Migrate {
 #[serde(rename_all = "camelCase")]
 pub struct RepoOp {
     pub action: String,
-    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cid: Option<cid::Cid>,
+    pub path: String,
 }
 #[doc = "`com.atproto.sync.subscribeRepos#tombstone`"]
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -60,4 +64,18 @@ pub struct Tombstone {
     pub did: String,
     pub seq: i32,
     pub time: String,
+}
+#[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "$type")]
+pub enum Message {
+    #[serde(rename = "com.atproto.sync.subscribeRepos#commit")]
+    Commit(Box<Commit>),
+    #[serde(rename = "com.atproto.sync.subscribeRepos#handle")]
+    Handle(Box<Handle>),
+    #[serde(rename = "com.atproto.sync.subscribeRepos#migrate")]
+    Migrate(Box<Migrate>),
+    #[serde(rename = "com.atproto.sync.subscribeRepos#tombstone")]
+    Tombstone(Box<Tombstone>),
+    #[serde(rename = "com.atproto.sync.subscribeRepos#info")]
+    Info(Box<Info>),
 }

--- a/atrium-api/src/com/atproto/sync/subscribe_repos.rs
+++ b/atrium-api/src/com/atproto/sync/subscribe_repos.rs
@@ -13,6 +13,11 @@ pub struct Commit {
     pub seq: i32,
     pub time: String,
     pub too_big: bool,
+    pub commit: cid::Cid,
+    pub prev: cid::Cid,
+    pub blobs: Vec<cid::Cid>,
+    #[serde(with = "serde_bytes")]
+    pub blocks: Vec<u8>,
 }
 #[doc = "`com.atproto.sync.subscribeRepos#handle`"]
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -46,6 +51,7 @@ pub struct Migrate {
 pub struct RepoOp {
     pub action: String,
     pub path: String,
+    pub cid: Option<cid::Cid>,
 }
 #[doc = "`com.atproto.sync.subscribeRepos#tombstone`"]
 #[derive(serde :: Serialize, serde :: Deserialize, Debug, Clone, PartialEq, Eq)]

--- a/atrium-api/src/records.rs
+++ b/atrium-api/src/records.rs
@@ -4,19 +4,19 @@
 #[serde(tag = "$type")]
 pub enum Record {
     #[serde(rename = "app.bsky.actor.profile")]
-    AppBskyActorProfile(crate::app::bsky::actor::profile::Record),
+    AppBskyActorProfile(Box<crate::app::bsky::actor::profile::Record>),
     #[serde(rename = "app.bsky.feed.like")]
-    AppBskyFeedLike(crate::app::bsky::feed::like::Record),
+    AppBskyFeedLike(Box<crate::app::bsky::feed::like::Record>),
     #[serde(rename = "app.bsky.feed.post")]
-    AppBskyFeedPost(crate::app::bsky::feed::post::Record),
+    AppBskyFeedPost(Box<crate::app::bsky::feed::post::Record>),
     #[serde(rename = "app.bsky.feed.repost")]
-    AppBskyFeedRepost(crate::app::bsky::feed::repost::Record),
+    AppBskyFeedRepost(Box<crate::app::bsky::feed::repost::Record>),
     #[serde(rename = "app.bsky.graph.block")]
-    AppBskyGraphBlock(crate::app::bsky::graph::block::Record),
+    AppBskyGraphBlock(Box<crate::app::bsky::graph::block::Record>),
     #[serde(rename = "app.bsky.graph.follow")]
-    AppBskyGraphFollow(crate::app::bsky::graph::follow::Record),
+    AppBskyGraphFollow(Box<crate::app::bsky::graph::follow::Record>),
     #[serde(rename = "app.bsky.graph.list")]
-    AppBskyGraphList(crate::app::bsky::graph::list::Record),
+    AppBskyGraphList(Box<crate::app::bsky::graph::list::Record>),
     #[serde(rename = "app.bsky.graph.listitem")]
-    AppBskyGraphListitem(crate::app::bsky::graph::listitem::Record),
+    AppBskyGraphListitem(Box<crate::app::bsky::graph::listitem::Record>),
 }

--- a/atrium-xrpc-server/Cargo.toml
+++ b/atrium-xrpc-server/Cargo.toml
@@ -7,6 +7,5 @@ edition = "2021"
 
 [dependencies]
 atrium-api = { path = "../atrium-api" }
-ciborium = "0.2.1"
-serde = { version = "1.0.163", features = ["derive"] }
+libipld-core = { version = "0.16.0", features = ["serde-codec"] }
 serde_ipld_dagcbor = "0.3.0"

--- a/atrium-xrpc-server/Cargo.toml
+++ b/atrium-xrpc-server/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "atrium-xrpc-server"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+atrium-api = { path = "../atrium-api" }
+ciborium = "0.2.1"
+serde = { version = "1.0.163", features = ["derive"] }
+serde_ipld_dagcbor = "0.3.0"

--- a/atrium-xrpc-server/src/lib.rs
+++ b/atrium-xrpc-server/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod stream;

--- a/atrium-xrpc-server/src/stream.rs
+++ b/atrium-xrpc-server/src/stream.rs
@@ -1,0 +1,1 @@
+pub mod frames;

--- a/atrium-xrpc-server/src/stream/frames.rs
+++ b/atrium-xrpc-server/src/stream/frames.rs
@@ -1,4 +1,4 @@
-use atrium_api::com::atproto::sync::subscribe_repos::{Commit, Handle, Info, Migrate, Tombstone};
+use atrium_api::com::atproto::sync::subscribe_repos::{Commit, Message};
 use libipld_core::ipld::Ipld;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
@@ -69,22 +69,13 @@ pub enum Frame {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MessageFrame {
-    pub body: MessageEnum,
+    pub body: Message,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ErrorFrame {
     // TODO
     // body: Value,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum MessageEnum {
-    Commit(Box<Commit>),
-    Handle(Box<Handle>),
-    Migrate(Box<Migrate>),
-    Tombstone(Box<Tombstone>),
-    Info(Box<Info>),
 }
 
 impl TryFrom<&[u8]> for Frame {
@@ -106,7 +97,7 @@ impl TryFrom<&[u8]> for Frame {
         match header {
             FrameHeader::Message(t) => match t.as_deref() {
                 Some("#commit") => Ok(Frame::Message(Box::new(MessageFrame {
-                    body: MessageEnum::Commit(Box::new(serde_ipld_dagcbor::from_slice::<Commit>(
+                    body: Message::Commit(Box::new(serde_ipld_dagcbor::from_slice::<Commit>(
                         right,
                     )?)),
                 }))),

--- a/atrium-xrpc-server/src/stream/frames.rs
+++ b/atrium-xrpc-server/src/stream/frames.rs
@@ -1,0 +1,178 @@
+use atrium_api::com::atproto::sync::subscribe_repos::Commit;
+use ciborium::Value;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use std::io::Cursor;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FrameTypeError;
+
+impl Display for FrameTypeError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid frame type")
+    }
+}
+
+impl Error for FrameTypeError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum FrameHeader {
+    Message(Option<String>),
+    Error,
+}
+
+// original definition:
+//```
+// export enum FrameType {
+//   Message = 1,
+//   Error = -1,
+// }
+// export const messageFrameHeader = z.object({
+//   op: z.literal(FrameType.Message), // Frame op
+//   t: z.string().optional(), // Message body type discriminator
+// })
+// export type MessageFrameHeader = z.infer<typeof messageFrameHeader>
+// export const errorFrameHeader = z.object({
+//   op: z.literal(FrameType.Error),
+// })
+// export type ErrorFrameHeader = z.infer<typeof errorFrameHeader>
+// ```
+impl TryFrom<Value> for FrameHeader {
+    type Error = FrameTypeError;
+
+    fn try_from(value: Value) -> Result<Self, <FrameHeader as TryFrom<Value>>::Error> {
+        let (mut op, mut t) = (None, None);
+        if let Some(map) = value.as_map() {
+            for (k, v) in map {
+                match (k.as_text(), v) {
+                    (Some("op"), Value::Integer(i)) => match i8::try_from(*i) {
+                        Ok(1) => op = Some(true),
+                        Ok(-1) => op = Some(false),
+                        _ => {}
+                    },
+                    (Some("t"), Value::Text(s)) => t = Some(s.clone()),
+                    _ => {}
+                }
+            }
+        }
+        if let Some(b) = op {
+            if b {
+                Ok(FrameHeader::Message(t))
+            } else {
+                Ok(FrameHeader::Error)
+            }
+        } else {
+            Err(FrameTypeError)
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Frame {
+    Message(MessageFrame),
+    Error(ErrorFrame),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MessageFrame {
+    pub body: MessageEnum,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ErrorFrame {
+    // TODO
+    // body: Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MessageEnum {
+    Commit(Commit),
+    // Handle(Handle),
+    // Migrate(Migrate),
+    // Tombstone(Tombstone),
+    // Info(Info),
+}
+
+impl TryFrom<&[u8]> for Frame {
+    type Error = Box<dyn Error>;
+
+    fn try_from(value: &[u8]) -> Result<Self, <Frame as TryFrom<&[u8]>>::Error> {
+        let mut cursor = Cursor::new(value);
+        let value = ciborium::de::from_reader::<Value, _>(&mut cursor)?;
+        let header = FrameHeader::try_from(value)?;
+        // println!(
+        //     "debug: {:?}",
+        //     ciborium::de::from_reader::<Value, _>(&mut cursor.clone())
+        // );
+        match header {
+            FrameHeader::Message(t) => match t.as_deref() {
+                Some("#commit") => Ok(Frame::Message(MessageFrame {
+                    body: MessageEnum::Commit(serde_ipld_dagcbor::from_reader::<Commit, _>(
+                        &mut cursor,
+                    )?),
+                })),
+                _ => unimplemented!(),
+            },
+            FrameHeader::Error => Ok(Frame::Error(ErrorFrame {})),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ciborium::Value;
+
+    fn serialize_value(value: &Value) -> Vec<u8> {
+        let mut buf = Vec::new();
+        ciborium::ser::into_writer(value, &mut buf).expect("failed to serialize");
+        buf
+    }
+
+    #[test]
+    fn deserialize_message_frame_header() {
+        let data = serialize_value(&Value::Map(vec![
+            (Value::Text("op".into()), Value::Integer(1.into())),
+            (Value::Text("t".into()), Value::Text("#commit".into())),
+        ]));
+        let value =
+            ciborium::de::from_reader::<Value, _>(data.as_slice()).expect("failed to deserialize");
+        assert_eq!(
+            FrameHeader::try_from(value),
+            Ok(FrameHeader::Message(Some(String::from("#commit"))))
+        );
+    }
+
+    #[test]
+    fn deserialize_error_frame_header() {
+        let data = serialize_value(&Value::Map(vec![(
+            Value::Text("op".into()),
+            Value::Integer((-1).into()),
+        )]));
+        let value =
+            ciborium::de::from_reader::<Value, _>(data.as_slice()).expect("failed to deserialize");
+        assert_eq!(FrameHeader::try_from(value), Ok(FrameHeader::Error));
+    }
+
+    #[test]
+    fn deserialize_invalid_frame_header() {
+        {
+            let data = serialize_value(&Value::Map(vec![
+                (Value::Text("op".into()), Value::Integer(2.into())),
+                (Value::Text("t".into()), Value::Text("#commit".into())),
+            ]));
+            let value = ciborium::de::from_reader::<Value, _>(data.as_slice())
+                .expect("failed to deserialize");
+            assert_eq!(FrameHeader::try_from(value), Err(FrameTypeError));
+        }
+        {
+            let data = serialize_value(&Value::Map(vec![(
+                Value::Text("op".into()),
+                Value::Integer((-2).into()),
+            )]));
+            let value = ciborium::de::from_reader::<Value, _>(data.as_slice())
+                .expect("failed to deserialize");
+            assert_eq!(FrameHeader::try_from(value), Err(FrameTypeError));
+        }
+    }
+}

--- a/atrium-xrpc-server/src/stream/frames.rs
+++ b/atrium-xrpc-server/src/stream/frames.rs
@@ -100,10 +100,6 @@ impl TryFrom<&[u8]> for Frame {
         let mut cursor = Cursor::new(value);
         let value = ciborium::de::from_reader::<Value, _>(&mut cursor)?;
         let header = FrameHeader::try_from(value)?;
-        // println!(
-        //     "debug: {:?}",
-        //     ciborium::de::from_reader::<Value, _>(&mut cursor.clone())
-        // );
         match header {
             FrameHeader::Message(t) => match t.as_deref() {
                 Some("#commit") => Ok(Frame::Message(MessageFrame {
@@ -111,7 +107,7 @@ impl TryFrom<&[u8]> for Frame {
                         &mut cursor,
                     )?),
                 })),
-                _ => unimplemented!(),
+                _ => unimplemented!("{t:?}"),
             },
             FrameHeader::Error => Ok(Frame::Error(ErrorFrame {})),
         }

--- a/examples/firehose/Cargo.toml
+++ b/examples/firehose/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "firehose"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+futures = "0.3.28"
+tokio = { version = "1.28.1", features = ["full"] }
+tokio-tungstenite = { version = "0.18.0", features = ["native-tls"] }

--- a/examples/firehose/Cargo.toml
+++ b/examples/firehose/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+atrium-api = { path = "../../atrium-api" }
+ciborium = "0.2.1"
 futures = "0.3.28"
+serde = { version = "1.0.163", features = ["derive"] }
 tokio = { version = "1.28.1", features = ["full"] }
 tokio-tungstenite = { version = "0.18.0", features = ["native-tls"] }

--- a/examples/firehose/Cargo.toml
+++ b/examples/firehose/Cargo.toml
@@ -7,8 +7,9 @@ edition = "2021"
 
 [dependencies]
 atrium-api = { path = "../../atrium-api" }
+atrium-xrpc-server = { path = "../../atrium-xrpc-server" }
 ciborium = "0.2.1"
 futures = "0.3.28"
-serde = { version = "1.0.163", features = ["derive"] }
+rs-car = "0.4.1"
 tokio = { version = "1.28.1", features = ["full"] }
 tokio-tungstenite = { version = "0.18.0", features = ["native-tls"] }

--- a/examples/firehose/src/main.rs
+++ b/examples/firehose/src/main.rs
@@ -26,8 +26,8 @@ async fn process_message(message: &[u8]) -> Result<(), Box<dyn std::error::Error
                         }
                         let (items, _) =
                             rs_car::car_read_all(&mut commit.blocks.as_slice(), true).await?;
-                        if let Some((cid, item)) = items.first() {
-                            assert_eq!(Some(*cid), op.cid);
+                        if let Some((_, item)) = items.iter().find(|(cid, _)| Some(*cid) == op.cid)
+                        {
                             if let Ok(value) =
                                 ciborium::de::from_reader::<Record, _>(&mut item.as_slice())
                             {
@@ -38,6 +38,7 @@ async fn process_message(message: &[u8]) -> Result<(), Box<dyn std::error::Error
                         }
                     }
                 }
+                _ => unimplemented!("{:?}", message.body),
             }
         }
         Frame::Error(err) => panic!("{err:?}"),

--- a/examples/firehose/src/main.rs
+++ b/examples/firehose/src/main.rs
@@ -1,12 +1,156 @@
+use atrium_api::com::atproto::sync::subscribe_repos::Commit;
+use ciborium::{from_reader, value::Integer, Value};
 use futures::StreamExt;
-use tokio_tungstenite::connect_async;
+use serde::{Deserialize, Serialize};
+use tokio_tungstenite::{connect_async, tungstenite};
+
+enum FrameType {
+    Message,
+    Error,
+}
+
+#[derive(Debug, Clone)]
+struct FrameTypeError;
+
+impl TryFrom<Integer> for FrameType {
+    type Error = FrameTypeError;
+
+    fn try_from(value: Integer) -> Result<Self, <FrameType as TryFrom<Integer>>::Error> {
+        match i8::try_from(value) {
+            Ok(1) => Ok(Self::Message),
+            Ok(-1) => Ok(Self::Error),
+            _ => Err(FrameTypeError),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct MessageFrameHeader {
+    t: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct ErrorFrameHeader {}
+
+#[derive(Debug, Clone)]
+enum FrameHeader {
+    Message(MessageFrameHeader),
+    Error(ErrorFrameHeader),
+}
+
+#[derive(Debug, Clone)]
+enum Frame {
+    Message(MessageFrame),
+    Error(ErrorFrame),
+}
+
+#[derive(Debug, Clone)]
+struct MessageFrame {
+    body: MessageEnum,
+}
+
+#[derive(Debug, Clone)]
+struct ErrorFrame {
+    // body: Value,
+}
+
+#[derive(Debug, Clone)]
+enum MessageEnum {
+    Commit(Commit),
+    // Handle(Handle),
+    // Migrate(Migrate),
+    // Tombstone(Tombstone),
+    // Info(Info),
+}
+
+impl Frame {
+    fn cbor_decode_multi(data: &[u8]) -> Result<Vec<Value>, ciborium::de::Error<std::io::Error>> {
+        let mut cursor = std::io::Cursor::new(data);
+        let mut values = Vec::new();
+        loop {
+            match from_reader::<Value, _>(&mut cursor) {
+                Ok(value) => values.push(value),
+                Err(ciborium::de::Error::Io(e))
+                    if e.kind() == std::io::ErrorKind::UnexpectedEof =>
+                {
+                    break
+                }
+                Err(err) => {
+                    return Err(err);
+                }
+            }
+        }
+        Ok(values)
+    }
+    fn parse_header(value: &Value) -> Result<FrameHeader, Box<dyn std::error::Error>> {
+        let op = value.as_map().and_then(|m| {
+            m.iter().find_map(|(k, v)| {
+                if k.as_text() == Some("op") {
+                    Some(v)
+                } else {
+                    None
+                }
+            })
+        });
+        if let Some(Value::Integer(i)) = op {
+            let mut buf = Vec::new();
+            ciborium::ser::into_writer(value, &mut buf)?;
+            match FrameType::try_from(*i) {
+                Ok(FrameType::Message) => {
+                    return Ok(FrameHeader::Message(from_reader(buf.as_slice())?));
+                }
+                Ok(FrameType::Error) => {
+                    return Ok(FrameHeader::Error(from_reader(buf.as_slice())?));
+                }
+                _ => {}
+            }
+        }
+        panic!("Invalid frame header.") // TODO
+    }
+}
+
+impl TryFrom<&[u8]> for Frame {
+    type Error = Box<dyn std::error::Error>;
+
+    fn try_from(value: &[u8]) -> Result<Self, <Frame as TryFrom<&[u8]>>::Error> {
+        let values = Self::cbor_decode_multi(value)?;
+        if values.len() <= 1 {
+            panic!("Missing frame body"); // TODO
+        }
+        if values.len() > 2 {
+            panic!("Too many CBOR data items in frame"); // TODO
+        }
+        Ok(match Self::parse_header(&values[0])? {
+            FrameHeader::Message(header) => {
+                let mut buf = Vec::new();
+                ciborium::ser::into_writer(&values[1], &mut buf)?;
+                match header.t.as_deref() {
+                    Some("#commit") => Self::Message(MessageFrame {
+                        body: MessageEnum::Commit(from_reader(buf.as_slice())?),
+                    }),
+                    _ => unimplemented!(),
+                }
+            }
+            FrameHeader::Error(_) => {
+                // TODO
+                Self::Error(ErrorFrame {})
+            }
+        })
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (mut stream, _) =
         connect_async("wss://bsky.social/xrpc/com.atproto.sync.subscribeRepos").await?;
-    while let Some(message) = stream.next().await {
-        println!("{message:?}");
+
+    while let Some(Ok(tungstenite::Message::Binary(message))) = stream.next().await {
+        match Frame::try_from(message.as_slice())? {
+            Frame::Message(message) => {
+                println!("{:?}", message.body);
+            }
+            Frame::Error(err) => panic!("{err:?}"),
+        }
     }
     Ok(())
 }

--- a/examples/firehose/src/main.rs
+++ b/examples/firehose/src/main.rs
@@ -1,143 +1,7 @@
-use atrium_api::com::atproto::sync::subscribe_repos::Commit;
-use ciborium::{from_reader, value::Integer, Value};
+use atrium_api::app::bsky::feed::post::Record;
+use atrium_xrpc_server::stream::frames::{Frame, MessageEnum};
 use futures::StreamExt;
-use serde::{Deserialize, Serialize};
 use tokio_tungstenite::{connect_async, tungstenite};
-
-enum FrameType {
-    Message,
-    Error,
-}
-
-#[derive(Debug, Clone)]
-struct FrameTypeError;
-
-impl TryFrom<Integer> for FrameType {
-    type Error = FrameTypeError;
-
-    fn try_from(value: Integer) -> Result<Self, <FrameType as TryFrom<Integer>>::Error> {
-        match i8::try_from(value) {
-            Ok(1) => Ok(Self::Message),
-            Ok(-1) => Ok(Self::Error),
-            _ => Err(FrameTypeError),
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-struct MessageFrameHeader {
-    t: Option<String>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-struct ErrorFrameHeader {}
-
-#[derive(Debug, Clone)]
-enum FrameHeader {
-    Message(MessageFrameHeader),
-    Error(ErrorFrameHeader),
-}
-
-#[derive(Debug, Clone)]
-enum Frame {
-    Message(MessageFrame),
-    Error(ErrorFrame),
-}
-
-#[derive(Debug, Clone)]
-struct MessageFrame {
-    body: MessageEnum,
-}
-
-#[derive(Debug, Clone)]
-struct ErrorFrame {
-    // body: Value,
-}
-
-#[derive(Debug, Clone)]
-enum MessageEnum {
-    Commit(Commit),
-    // Handle(Handle),
-    // Migrate(Migrate),
-    // Tombstone(Tombstone),
-    // Info(Info),
-}
-
-impl Frame {
-    fn cbor_decode_multi(data: &[u8]) -> Result<Vec<Value>, ciborium::de::Error<std::io::Error>> {
-        let mut cursor = std::io::Cursor::new(data);
-        let mut values = Vec::new();
-        loop {
-            match from_reader::<Value, _>(&mut cursor) {
-                Ok(value) => values.push(value),
-                Err(ciborium::de::Error::Io(e))
-                    if e.kind() == std::io::ErrorKind::UnexpectedEof =>
-                {
-                    break
-                }
-                Err(err) => {
-                    return Err(err);
-                }
-            }
-        }
-        Ok(values)
-    }
-    fn parse_header(value: &Value) -> Result<FrameHeader, Box<dyn std::error::Error>> {
-        let op = value.as_map().and_then(|m| {
-            m.iter().find_map(|(k, v)| {
-                if k.as_text() == Some("op") {
-                    Some(v)
-                } else {
-                    None
-                }
-            })
-        });
-        if let Some(Value::Integer(i)) = op {
-            let mut buf = Vec::new();
-            ciborium::ser::into_writer(value, &mut buf)?;
-            match FrameType::try_from(*i) {
-                Ok(FrameType::Message) => {
-                    return Ok(FrameHeader::Message(from_reader(buf.as_slice())?));
-                }
-                Ok(FrameType::Error) => {
-                    return Ok(FrameHeader::Error(from_reader(buf.as_slice())?));
-                }
-                _ => {}
-            }
-        }
-        panic!("Invalid frame header.") // TODO
-    }
-}
-
-impl TryFrom<&[u8]> for Frame {
-    type Error = Box<dyn std::error::Error>;
-
-    fn try_from(value: &[u8]) -> Result<Self, <Frame as TryFrom<&[u8]>>::Error> {
-        let values = Self::cbor_decode_multi(value)?;
-        if values.len() <= 1 {
-            panic!("Missing frame body"); // TODO
-        }
-        if values.len() > 2 {
-            panic!("Too many CBOR data items in frame"); // TODO
-        }
-        Ok(match Self::parse_header(&values[0])? {
-            FrameHeader::Message(header) => {
-                let mut buf = Vec::new();
-                ciborium::ser::into_writer(&values[1], &mut buf)?;
-                match header.t.as_deref() {
-                    Some("#commit") => Self::Message(MessageFrame {
-                        body: MessageEnum::Commit(from_reader(buf.as_slice())?),
-                    }),
-                    _ => unimplemented!(),
-                }
-            }
-            FrameHeader::Error(_) => {
-                // TODO
-                Self::Error(ErrorFrame {})
-            }
-        })
-    }
-}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -146,9 +10,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     while let Some(Ok(tungstenite::Message::Binary(message))) = stream.next().await {
         match Frame::try_from(message.as_slice())? {
-            Frame::Message(message) => {
-                println!("{:?}", message.body);
-            }
+            Frame::Message(message) => match message.body {
+                MessageEnum::Commit(commit) => {
+                    // println!("{:?}: {:?}", commit.commit, commit.ops);
+                    if let Some(op) = commit.ops.iter().find(|op| {
+                        op.action == "create" && op.path.starts_with("app.bsky.feed.post")
+                    }) {
+                        let (items, _) =
+                            rs_car::car_read_all(&mut commit.blocks.as_slice(), true).await?;
+                        if let Some((cid, item)) = items.first() {
+                            assert_eq!(Some(*cid), op.cid);
+                            if let Ok(value) =
+                                ciborium::de::from_reader::<Record, _>(&mut item.as_slice())
+                            {
+                                println!("{}: {}", value.created_at, value.text.replace('\n', " "));
+                            } else {
+                                // TODO
+                            }
+                        }
+                    }
+                }
+            },
             Frame::Error(err) => panic!("{err:?}"),
         }
     }

--- a/examples/firehose/src/main.rs
+++ b/examples/firehose/src/main.rs
@@ -1,5 +1,6 @@
 use atrium_api::app::bsky::feed::post::Record;
-use atrium_xrpc_server::stream::frames::{Frame, MessageEnum};
+use atrium_api::com::atproto::sync::subscribe_repos::Message;
+use atrium_xrpc_server::stream::frames::Frame;
 use futures::StreamExt;
 use tokio_tungstenite::{connect_async, tungstenite};
 
@@ -18,7 +19,7 @@ async fn process_message(message: &[u8]) -> Result<(), Box<dyn std::error::Error
     match Frame::try_from(message)? {
         Frame::Message(message) => {
             match message.body {
-                MessageEnum::Commit(commit) => {
+                Message::Commit(commit) => {
                     for op in commit.ops {
                         let collection = op.path.split('/').next().expect("op.path is empty");
                         if op.action != "create" || collection != "app.bsky.feed.post" {

--- a/examples/firehose/src/main.rs
+++ b/examples/firehose/src/main.rs
@@ -1,0 +1,12 @@
+use futures::StreamExt;
+use tokio_tungstenite::connect_async;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let (mut stream, _) =
+        connect_async("wss://bsky.social/xrpc/com.atproto.sync.subscribeRepos").await?;
+    while let Some(message) = stream.next().await {
+        println!("{message:?}");
+    }
+    Ok(())
+}


### PR DESCRIPTION
resolves #11 

- Add `atrium-xrpc-server` member which handles message frames from subscription streams
- Add `examples/firehose`, it subscribes and prints all texts of posts
  - ref: https://github.com/bluesky-social/feed-generator/blob/main/src/util/subscription.ts
- Update `codegen` and APIs for these subscription messages

https://github.com/sugyan/atrium/assets/80381/061fb8c4-4cca-4b90-9865-b642dbcd6c45

