### PR TITLE
Fix broken array URL encoding

### DIFF
--- a/atrium-api/Cargo.toml
+++ b/atrium-api/Cargo.toml
@@ -18,7 +18,7 @@ http = "0.2.9"
 serde = { version = "1.0.160", features = ["derive"] }
 serde_bytes = "0.11.9"
 serde_json = "1.0.96"
-serde_urlencoded = "0.7.1"
+serde_qs = "0.12.0"
 
 [dev-dependencies]
 tokio = { version = "1.28.0", features = ["macros", "rt"] }

--- a/atrium-api/src/app/bsky/actor/get_preferences.rs
+++ b/atrium-api/src/app/bsky/actor/get_preferences.rs
@@ -12,7 +12,7 @@ pub trait GetPreferences: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.actor.getPreferences",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/actor/get_profile.rs
+++ b/atrium-api/src/app/bsky/actor/get_profile.rs
@@ -8,7 +8,7 @@ pub trait GetProfile: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.actor.getProfile",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/actor/get_profiles.rs
+++ b/atrium-api/src/app/bsky/actor/get_profiles.rs
@@ -8,7 +8,7 @@ pub trait GetProfiles: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.actor.getProfiles",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/actor/get_suggestions.rs
+++ b/atrium-api/src/app/bsky/actor/get_suggestions.rs
@@ -12,7 +12,7 @@ pub trait GetSuggestions: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.actor.getSuggestions",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/actor/search_actors.rs
+++ b/atrium-api/src/app/bsky/actor/search_actors.rs
@@ -12,7 +12,7 @@ pub trait SearchActors: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.actor.searchActors",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/actor/search_actors_typeahead.rs
+++ b/atrium-api/src/app/bsky/actor/search_actors_typeahead.rs
@@ -12,7 +12,7 @@ pub trait SearchActorsTypeahead: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.actor.searchActorsTypeahead",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/feed/get_actor_feeds.rs
+++ b/atrium-api/src/app/bsky/feed/get_actor_feeds.rs
@@ -12,7 +12,7 @@ pub trait GetActorFeeds: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.feed.getActorFeeds",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/feed/get_author_feed.rs
+++ b/atrium-api/src/app/bsky/feed/get_author_feed.rs
@@ -12,7 +12,7 @@ pub trait GetAuthorFeed: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.feed.getAuthorFeed",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/feed/get_feed.rs
+++ b/atrium-api/src/app/bsky/feed/get_feed.rs
@@ -9,7 +9,7 @@ pub trait GetFeed: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.feed.getFeed",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/feed/get_feed_generator.rs
+++ b/atrium-api/src/app/bsky/feed/get_feed_generator.rs
@@ -12,7 +12,7 @@ pub trait GetFeedGenerator: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.feed.getFeedGenerator",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/feed/get_feed_generators.rs
+++ b/atrium-api/src/app/bsky/feed/get_feed_generators.rs
@@ -12,7 +12,7 @@ pub trait GetFeedGenerators: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.feed.getFeedGenerators",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/feed/get_feed_skeleton.rs
+++ b/atrium-api/src/app/bsky/feed/get_feed_skeleton.rs
@@ -12,7 +12,7 @@ pub trait GetFeedSkeleton: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.feed.getFeedSkeleton",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/feed/get_likes.rs
+++ b/atrium-api/src/app/bsky/feed/get_likes.rs
@@ -8,7 +8,7 @@ pub trait GetLikes: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.feed.getLikes",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/feed/get_post_thread.rs
+++ b/atrium-api/src/app/bsky/feed/get_post_thread.rs
@@ -11,7 +11,7 @@ pub trait GetPostThread: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.feed.getPostThread",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/feed/get_posts.rs
+++ b/atrium-api/src/app/bsky/feed/get_posts.rs
@@ -9,7 +9,7 @@ pub trait GetPosts: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.feed.getPosts",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/feed/get_reposted_by.rs
+++ b/atrium-api/src/app/bsky/feed/get_reposted_by.rs
@@ -11,7 +11,7 @@ pub trait GetRepostedBy: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.feed.getRepostedBy",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/feed/get_timeline.rs
+++ b/atrium-api/src/app/bsky/feed/get_timeline.rs
@@ -9,7 +9,7 @@ pub trait GetTimeline: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.feed.getTimeline",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/graph/get_blocks.rs
+++ b/atrium-api/src/app/bsky/graph/get_blocks.rs
@@ -9,7 +9,7 @@ pub trait GetBlocks: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.graph.getBlocks",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/graph/get_followers.rs
+++ b/atrium-api/src/app/bsky/graph/get_followers.rs
@@ -12,7 +12,7 @@ pub trait GetFollowers: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.graph.getFollowers",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/graph/get_follows.rs
+++ b/atrium-api/src/app/bsky/graph/get_follows.rs
@@ -9,7 +9,7 @@ pub trait GetFollows: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.graph.getFollows",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/graph/get_list.rs
+++ b/atrium-api/src/app/bsky/graph/get_list.rs
@@ -9,7 +9,7 @@ pub trait GetList: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.graph.getList",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/graph/get_list_mutes.rs
+++ b/atrium-api/src/app/bsky/graph/get_list_mutes.rs
@@ -12,7 +12,7 @@ pub trait GetListMutes: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.graph.getListMutes",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/graph/get_lists.rs
+++ b/atrium-api/src/app/bsky/graph/get_lists.rs
@@ -9,7 +9,7 @@ pub trait GetLists: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.graph.getLists",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/graph/get_mutes.rs
+++ b/atrium-api/src/app/bsky/graph/get_mutes.rs
@@ -9,7 +9,7 @@ pub trait GetMutes: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.graph.getMutes",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/notification/get_unread_count.rs
+++ b/atrium-api/src/app/bsky/notification/get_unread_count.rs
@@ -11,7 +11,7 @@ pub trait GetUnreadCount: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.notification.getUnreadCount",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/notification/list_notifications.rs
+++ b/atrium-api/src/app/bsky/notification/list_notifications.rs
@@ -11,7 +11,7 @@ pub trait ListNotifications: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.notification.listNotifications",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/app/bsky/unspecced/get_popular.rs
+++ b/atrium-api/src/app/bsky/unspecced/get_popular.rs
@@ -9,7 +9,7 @@ pub trait GetPopular: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "app.bsky.unspecced.getPopular",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/com/atproto/admin/get_invite_codes.rs
+++ b/atrium-api/src/com/atproto/admin/get_invite_codes.rs
@@ -12,7 +12,7 @@ pub trait GetInviteCodes: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "com.atproto.admin.getInviteCodes",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/com/atproto/admin/get_moderation_action.rs
+++ b/atrium-api/src/com/atproto/admin/get_moderation_action.rs
@@ -12,7 +12,7 @@ pub trait GetModerationAction: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "com.atproto.admin.getModerationAction",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/com/atproto/admin/get_moderation_actions.rs
+++ b/atrium-api/src/com/atproto/admin/get_moderation_actions.rs
@@ -12,7 +12,7 @@ pub trait GetModerationActions: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "com.atproto.admin.getModerationActions",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/com/atproto/admin/get_moderation_report.rs
+++ b/atrium-api/src/com/atproto/admin/get_moderation_report.rs
@@ -12,7 +12,7 @@ pub trait GetModerationReport: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "com.atproto.admin.getModerationReport",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/com/atproto/admin/get_moderation_reports.rs
+++ b/atrium-api/src/com/atproto/admin/get_moderation_reports.rs
@@ -12,7 +12,7 @@ pub trait GetModerationReports: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "com.atproto.admin.getModerationReports",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/com/atproto/admin/get_record.rs
+++ b/atrium-api/src/com/atproto/admin/get_record.rs
@@ -9,7 +9,7 @@ pub trait GetRecord: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "com.atproto.admin.getRecord",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/com/atproto/admin/get_repo.rs
+++ b/atrium-api/src/com/atproto/admin/get_repo.rs
@@ -9,7 +9,7 @@ pub trait GetRepo: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "com.atproto.admin.getRepo",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/com/atproto/admin/search_repos.rs
+++ b/atrium-api/src/com/atproto/admin/search_repos.rs
@@ -9,7 +9,7 @@ pub trait SearchRepos: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "com.atproto.admin.searchRepos",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/com/atproto/identity/resolve_handle.rs
+++ b/atrium-api/src/com/atproto/identity/resolve_handle.rs
@@ -12,7 +12,7 @@ pub trait ResolveHandle: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "com.atproto.identity.resolveHandle",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/com/atproto/label/query_labels.rs
+++ b/atrium-api/src/com/atproto/label/query_labels.rs
@@ -9,7 +9,7 @@ pub trait QueryLabels: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "com.atproto.label.queryLabels",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/com/atproto/repo/describe_repo.rs
+++ b/atrium-api/src/com/atproto/repo/describe_repo.rs
@@ -12,7 +12,7 @@ pub trait DescribeRepo: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "com.atproto.repo.describeRepo",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/com/atproto/repo/get_record.rs
+++ b/atrium-api/src/com/atproto/repo/get_record.rs
@@ -9,7 +9,7 @@ pub trait GetRecord: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "com.atproto.repo.getRecord",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/com/atproto/repo/list_records.rs
+++ b/atrium-api/src/com/atproto/repo/list_records.rs
@@ -9,7 +9,7 @@ pub trait ListRecords: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "com.atproto.repo.listRecords",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/com/atproto/server/get_account_invite_codes.rs
+++ b/atrium-api/src/com/atproto/server/get_account_invite_codes.rs
@@ -12,7 +12,7 @@ pub trait GetAccountInviteCodes: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "com.atproto.server.getAccountInviteCodes",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/com/atproto/sync/get_blob.rs
+++ b/atrium-api/src/com/atproto/sync/get_blob.rs
@@ -9,7 +9,7 @@ pub trait GetBlob: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "com.atproto.sync.getBlob",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/com/atproto/sync/get_blocks.rs
+++ b/atrium-api/src/com/atproto/sync/get_blocks.rs
@@ -9,7 +9,7 @@ pub trait GetBlocks: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "com.atproto.sync.getBlocks",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/com/atproto/sync/get_checkout.rs
+++ b/atrium-api/src/com/atproto/sync/get_checkout.rs
@@ -9,7 +9,7 @@ pub trait GetCheckout: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "com.atproto.sync.getCheckout",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/com/atproto/sync/get_commit_path.rs
+++ b/atrium-api/src/com/atproto/sync/get_commit_path.rs
@@ -12,7 +12,7 @@ pub trait GetCommitPath: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "com.atproto.sync.getCommitPath",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/com/atproto/sync/get_head.rs
+++ b/atrium-api/src/com/atproto/sync/get_head.rs
@@ -9,7 +9,7 @@ pub trait GetHead: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "com.atproto.sync.getHead",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/com/atproto/sync/get_record.rs
+++ b/atrium-api/src/com/atproto/sync/get_record.rs
@@ -9,7 +9,7 @@ pub trait GetRecord: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "com.atproto.sync.getRecord",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/com/atproto/sync/get_repo.rs
+++ b/atrium-api/src/com/atproto/sync/get_repo.rs
@@ -9,7 +9,7 @@ pub trait GetRepo: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "com.atproto.sync.getRepo",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/com/atproto/sync/list_blobs.rs
+++ b/atrium-api/src/com/atproto/sync/list_blobs.rs
@@ -9,7 +9,7 @@ pub trait ListBlobs: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "com.atproto.sync.listBlobs",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/com/atproto/sync/list_repos.rs
+++ b/atrium-api/src/com/atproto/sync/list_repos.rs
@@ -9,7 +9,7 @@ pub trait ListRepos: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "com.atproto.sync.listRepos",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/com/atproto/sync/notify_of_update.rs
+++ b/atrium-api/src/com/atproto/sync/notify_of_update.rs
@@ -9,7 +9,7 @@ pub trait NotifyOfUpdate: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "com.atproto.sync.notifyOfUpdate",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/com/atproto/sync/request_crawl.rs
+++ b/atrium-api/src/com/atproto/sync/request_crawl.rs
@@ -9,7 +9,7 @@ pub trait RequestCrawl: crate::xrpc::XrpcClient {
             self,
             http::Method::GET,
             "com.atproto.sync.requestCrawl",
-            Some(serde_urlencoded::to_string(&params)?),
+            Some(serde_qs::to_string(&params)?),
             None,
             None,
         )

--- a/atrium-api/src/xrpc.rs
+++ b/atrium-api/src/xrpc.rs
@@ -125,7 +125,7 @@ mod tests {
                     self,
                     http::Method::GET,
                     "example",
-                    Some(serde_urlencoded::to_string(&params)?),
+                    Some(serde_qs::to_string(&params)?),
                     None,
                     None,
                 )

--- a/atrium-codegen/src/token_stream.rs
+++ b/atrium-codegen/src/token_stream.rs
@@ -214,7 +214,7 @@ impl LexConverter {
             args.push(quote!(params: Parameters));
         }
         let param_value = if has_params {
-            quote!(Some(serde_urlencoded::to_string(&params)?))
+            quote!(Some(serde_qs::to_string(&params)?))
         } else {
             quote!(None)
         };

--- a/atrium-xrpc/Cargo.toml
+++ b/atrium-xrpc/Cargo.toml
@@ -16,7 +16,7 @@ http = "0.2.9"
 reqwest = "0.11.16"
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.96"
-serde_urlencoded = "0.7.1"
+serde_qs = "0.12.0"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/atrium-xrpc/src/error.rs
+++ b/atrium-xrpc/src/error.rs
@@ -73,6 +73,6 @@ where
     HttpClient(Box<dyn std::error::Error + Send + Sync + 'static>),
     #[error("serde_json error: {0}")]
     SerdeJson(#[from] serde_json::Error),
-    #[error("serde_urlencoded error: {0}")]
-    SerdeUrlencoded(#[from] serde_urlencoded::ser::Error),
+    #[error("serde_qs error: {0}")]
+    SerdeQs(#[from] serde_qs::ser::Error),
 }

--- a/atrium-xrpc/src/error.rs
+++ b/atrium-xrpc/src/error.rs
@@ -74,5 +74,5 @@ where
     #[error("serde_json error: {0}")]
     SerdeJson(#[from] serde_json::Error),
     #[error("serde_qs error: {0}")]
-    SerdeQs(#[from] serde_qs::ser::Error),
+    SerdeQs(#[from] serde_qs::Error),
 }

--- a/atrium-xrpc/src/lib.rs
+++ b/atrium-xrpc/src/lib.rs
@@ -74,7 +74,7 @@ mod tests {
                     self,
                     http::Method::GET,
                     "example",
-                    Some(serde_urlencoded::to_string(&params)?),
+                    Some(serde_qs::to_string(&params)?),
                     None,
                     None,
                 )


### PR DESCRIPTION
Switch from serde_urlencoded to a library named serde_qs. serde_urlencoded [does not support arrays and has no plan to](https://github.com/nox/serde_urlencoded/issues/52#issuecomment-483138575), so this switches to a fork called serde_qs, which does support common but non-standard query parameters in URLs.

This was breaking `get_posts` (and probably others). I tested after and `get_posts` works now. I initially made the changes to codegen and regenerated atrium-api and tested it after that - but it also picked up some other unrelated changes due to changes to the lexicons, so I revered that and made only the relevant changes manually with sed.