### PR TITLE
Add `is_refresh` argument to atrium-api `XrpcClient::auth`

### DIFF
--- a/atrium-api/README.md
+++ b/atrium-api/README.md
@@ -37,7 +37,7 @@ impl atrium_api::xrpc::XrpcClient for MyClient {
     fn host(&self) -> &str {
         "https://bsky.social"
     }
-    fn auth(&self) -> Option<&str> {
+    fn auth(&self, _: bool) -> Option<&str> {
         None
     }
 }


### PR DESCRIPTION
I was unable to use `refresh_session()` and, looking around, I noticed the `atrium-xrpc` crate's [implementation](https://github.com/sugyan/atrium/blob/621865ac75defd0fad50a906ff6a0490f31e80e3/atrium-xrpc/src/lib.rs#L24) of `XrpcClient` has an `is_refresh` parameter to the `auth` method and [a corresponding way](https://github.com/sugyan/atrium/blob/621865ac75defd0fad50a906ff6a0490f31e80e3/atrium-xrpc/src/lib.rs#L48) to detect refreshes and set that parameter, enabling refreshes. I basically just copied it into the `atrium-api` version of the trait, which lets me successfully use `refresh_session()`. I don't think there's a way for `refresh_session()` to work without this. 