### PR TITLE
atrium-xrpc-server: don't panic when parsing unimplemented frames

### DIFF
--- a/atrium-xrpc-server/src/stream/frames.rs
+++ b/atrium-xrpc-server/src/stream/frames.rs
@@ -88,7 +88,10 @@ impl TryFrom<&[u8]> for Frame {
                         right,
                     )?)),
                 }))),
-                _ => unimplemented!("{t:?}"),
+                _ => {
+                    let tag = t.as_deref();
+                    Err(anyhow::anyhow!("frame not implemented: tag={tag:?}"))
+                },
             },
             FrameHeader::Error => Ok(Frame::Error(ErrorFrame {})),
         }


### PR DESCRIPTION
avoid `panic`ing unsupported frames when parsing from websocket