### PR TITLE
Change trait method names

### DIFF
--- a/atrium-xrpc/src/client/reqwest.rs
+++ b/atrium-xrpc/src/client/reqwest.rs
@@ -21,7 +21,7 @@ impl ReqwestClient {
 
 #[async_trait]
 impl HttpClient for ReqwestClient {
-    async fn send(
+    async fn send_http(
         &self,
         req: Request<Vec<u8>>,
     ) -> Result<Response<Vec<u8>>, Box<dyn Error + Send + Sync + 'static>> {


### PR DESCRIPTION
Rename method names of XRPC traits
- `HttpClient::send` -> `send_http`
- `XrpcClient::send` -> `send_xrpc`

Having methods with the same name causes confusion when calling a method in the struct that implements them, so to avoid this, change the method name to be distinct in each trait.