### PR TITLE
Delegate to inner XrpcClient in AtpServiceWrapper

### DIFF
--- a/atrium-api/src/client.rs
+++ b/atrium-api/src/client.rs
@@ -56,12 +56,34 @@ where
     }
 }
 
+#[async_trait]
 impl<T> XrpcClient for AtpServiceWrapper<T>
 where
     T: XrpcClient + Send + Sync,
 {
     fn host(&self) -> &str {
         self.xrpc.host()
+    }
+    fn auth(&self, is_refresh: bool) -> Option<String> {
+        self.xrpc.auth(is_refresh)
+    }
+    async fn send_xrpc<P, I, O, E>(
+        &self,
+        method: http::Method,
+        path: &str,
+        parameters: Option<P>,
+        input: Option<InputDataOrBytes<I>>,
+        encoding: Option<String>,
+    ) -> Result<OutputDataOrBytes<O>, atrium_xrpc::error::Error<E>>
+    where
+        P: serde::Serialize + Send,
+        I: serde::Serialize + Send,
+        O: serde::de::DeserializeOwned,
+        E: serde::de::DeserializeOwned,
+    {
+        self.xrpc
+            .send_xrpc(method, path, parameters, input, encoding)
+            .await
     }
 }
 


### PR DESCRIPTION
AtpServiceWrapper only delegates `host()` to the inner xrpc client. This means that the default methods provided by the trait will be used for `auth()` and `send_xrpc()` - meaning that even if the inner struct provides one of these methods, it won't be used. Since the default method for `auth` provided by the trait always returns `None`, this breaks authentication.