### PR TITLE
Update firehose example to latest library and endpoint

### DIFF
--- a/atrium-xrpc-server/Cargo.toml
+++ b/atrium-xrpc-server/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atrium-api = "0.3"
+atrium-api = "0.13"
 anyhow = "1.0.71"
 libipld-core = { version = "0.16.0", features = ["serde-codec"] }
 serde_ipld_dagcbor = "0.3.0"

--- a/examples/firehose/Cargo.toml
+++ b/examples/firehose/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 atrium-xrpc-server = { path = "../../atrium-xrpc-server" }
-atrium-api = "0.3"
+atrium-api = "0.13"
 ciborium = "0.2.1"
 futures = "0.3.28"
 rs-car = "0.4.1"

--- a/examples/firehose/src/main.rs
+++ b/examples/firehose/src/main.rs
@@ -7,10 +7,10 @@ use tokio_tungstenite::{connect_async, tungstenite};
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (mut stream, _) =
-        connect_async("wss://bsky.social/xrpc/com.atproto.sync.subscribeRepos").await?;
+        connect_async("wss://bsky.network/xrpc/com.atproto.sync.subscribeRepos").await?;
 
     while let Some(Ok(tungstenite::Message::Binary(message))) = stream.next().await {
-        process_message(&message).await?;
+        process_message(&message).await.unwrap();
     }
     Ok(())
 }


### PR DESCRIPTION
Updated firehose example to use `0.13` of `atrium-api` and updated endpoint to use new `bsky.network` endpoint.  As libraries have to be matched, also updated `atrium-xrpc-server` to use latest `0.13` version of `atrium-api`.