### PR TITLE
Update examples/concurrent

### DIFF
--- a/examples/concurrent/Cargo.toml
+++ b/examples/concurrent/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atrium-api = "0.11"
+atrium-api = "0.14"
+atrium-xrpc-client = "0.2"
 clap = { version = "4.4.7", features = ["derive"] }
 futures = "0.3.29"
 tokio = { version = "1.33.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/concurrent/src/main.rs
+++ b/examples/concurrent/src/main.rs
@@ -1,5 +1,5 @@
-use atrium_api::agent::AtpAgent;
-use atrium_api::xrpc::client::reqwest::ReqwestClient;
+use atrium_api::agent::{store::MemorySessionStore, AtpAgent};
+use atrium_xrpc_client::reqwest::ReqwestClient;
 use clap::Parser;
 use futures::future::join_all;
 use std::sync::Arc;
@@ -19,11 +19,11 @@ struct Args {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
-    let agent = Arc::new(AtpAgent::new(ReqwestClient::new(
-        "https://bsky.social".into(),
-    )));
+    let agent = Arc::new(AtpAgent::new(
+        ReqwestClient::new("https://bsky.social"),
+        MemorySessionStore::default(),
+    ));
     agent.login(&args.identifier, &args.password).await?;
-
     let actors = ["bsky.app", "atproto.com", "safety.bsky.app"];
     let handles = actors
         .iter()


### PR DESCRIPTION
- Use `atrium-api 0.14` and `atrium-xrpc-client 0.2`