### PR TITLE
atrium-api: Fix serde deserialization of `Cid` and `Datetime`

### DIFF
--- a/atrium-api/CHANGELOG.md
+++ b/atrium-api/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `atrium_api::types::string::{Cid, Datetime}` can now be deserialized with `serde`.
+
 ## [0.17.2](https://github.com/sugyan/atrium/compare/atrium-api-v0.17.1...atrium-api-v0.17.2) - 2024-02-21
 
 ### Other

--- a/atrium-api/src/types/string.rs
+++ b/atrium-api/src/types/string.rs
@@ -129,8 +129,8 @@ impl<'de> Deserialize<'de> for Cid {
     where
         D: Deserializer<'de>,
     {
-        let value = Deserialize::deserialize(deserializer)?;
-        Self::from_str(value).map_err(D::Error::custom)
+        let value: String = Deserialize::deserialize(deserializer)?;
+        Self::from_str(&value).map_err(D::Error::custom)
     }
 }
 
@@ -227,8 +227,8 @@ impl<'de> Deserialize<'de> for Datetime {
     where
         D: Deserializer<'de>,
     {
-        let value = Deserialize::deserialize(deserializer)?;
-        Self::from_str(value).map_err(D::Error::custom)
+        let value: String = Deserialize::deserialize(deserializer)?;
+        Self::from_str(&value).map_err(D::Error::custom)
     }
 }
 


### PR DESCRIPTION
`Deserialize::deserialize` apparently is implemented somewhere for a return type of `&str`, but that does not work in practice; an intermediate `String` is required to actually deserialize with a library like `serde_ipld_dagcbor`.