### PR TITLE
Generate structs corresponding to collections

### DIFF
--- a/atrium-api/CHANGELOG.md
+++ b/atrium-api/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `atrium_api::types::Collection` trait, which binds together a record type and its NSID.
+- Collection structs for the current record types:
+  - `atrium_api::app::bsky::actor::Profile`
+  - `atrium_api::app::bsky::feed`:
+    - `Generator`
+    - `Like`
+    - `Post`
+    - `Repost`
+    - `Threadgate`
+  - `atrium_api::app::bsky::graph`:
+    - `Block`
+    - `Follow`
+    - `List`
+    - `Listblock`
+    - `Listitem`
+
 ## [0.18.0](https://github.com/sugyan/atrium/compare/atrium-api-v0.17.2...atrium-api-v0.18.0) - 2024-02-29
 
 ### Added

--- a/atrium-api/src/app/bsky/actor.rs
+++ b/atrium-api/src/app/bsky/actor.rs
@@ -9,3 +9,9 @@ pub mod profile;
 pub mod put_preferences;
 pub mod search_actors;
 pub mod search_actors_typeahead;
+#[derive(Debug)]
+pub struct Profile;
+impl crate::types::Collection for Profile {
+    const NSID: &'static str = "app.bsky.actor.profile";
+    type Record = profile::Record;
+}

--- a/atrium-api/src/app/bsky/feed.rs
+++ b/atrium-api/src/app/bsky/feed.rs
@@ -22,3 +22,33 @@ pub mod post;
 pub mod repost;
 pub mod search_posts;
 pub mod threadgate;
+#[derive(Debug)]
+pub struct Generator;
+impl crate::types::Collection for Generator {
+    const NSID: &'static str = "app.bsky.feed.generator";
+    type Record = generator::Record;
+}
+#[derive(Debug)]
+pub struct Like;
+impl crate::types::Collection for Like {
+    const NSID: &'static str = "app.bsky.feed.like";
+    type Record = like::Record;
+}
+#[derive(Debug)]
+pub struct Post;
+impl crate::types::Collection for Post {
+    const NSID: &'static str = "app.bsky.feed.post";
+    type Record = post::Record;
+}
+#[derive(Debug)]
+pub struct Repost;
+impl crate::types::Collection for Repost {
+    const NSID: &'static str = "app.bsky.feed.repost";
+    type Record = repost::Record;
+}
+#[derive(Debug)]
+pub struct Threadgate;
+impl crate::types::Collection for Threadgate {
+    const NSID: &'static str = "app.bsky.feed.threadgate";
+    type Record = threadgate::Record;
+}

--- a/atrium-api/src/app/bsky/graph.rs
+++ b/atrium-api/src/app/bsky/graph.rs
@@ -20,3 +20,33 @@ pub mod mute_actor;
 pub mod mute_actor_list;
 pub mod unmute_actor;
 pub mod unmute_actor_list;
+#[derive(Debug)]
+pub struct Block;
+impl crate::types::Collection for Block {
+    const NSID: &'static str = "app.bsky.graph.block";
+    type Record = block::Record;
+}
+#[derive(Debug)]
+pub struct Follow;
+impl crate::types::Collection for Follow {
+    const NSID: &'static str = "app.bsky.graph.follow";
+    type Record = follow::Record;
+}
+#[derive(Debug)]
+pub struct List;
+impl crate::types::Collection for List {
+    const NSID: &'static str = "app.bsky.graph.list";
+    type Record = list::Record;
+}
+#[derive(Debug)]
+pub struct Listblock;
+impl crate::types::Collection for Listblock {
+    const NSID: &'static str = "app.bsky.graph.listblock";
+    type Record = listblock::Record;
+}
+#[derive(Debug)]
+pub struct Listitem;
+impl crate::types::Collection for Listitem {
+    const NSID: &'static str = "app.bsky.graph.listitem";
+    type Record = listitem::Record;
+}

--- a/lexicon/atrium-codegen/src/lib.rs
+++ b/lexicon/atrium-codegen/src/lib.rs
@@ -33,7 +33,7 @@ pub fn genapi(
     }
     results.push(generate_records(&outdir, &schemas)?);
     results.push(generate_client(&outdir, &schemas)?);
-    results.extend(generate_modules(&outdir)?);
+    results.extend(generate_modules(&outdir, &schemas)?);
     Ok(results)
 }
 

--- a/lexicon/atrium-codegen/src/token_stream.rs
+++ b/lexicon/atrium-codegen/src/token_stream.rs
@@ -39,6 +39,19 @@ pub fn ref_unions(schema_id: &str, ref_unions: &[(String, LexRefUnion)]) -> Resu
     Ok(quote!(#(#enums)*))
 }
 
+pub fn collection(name: &str, nsid: &str) -> TokenStream {
+    let module_name = format_ident!("{name}");
+    let collection_name = format_ident!("{}", name.to_pascal_case());
+    quote! {
+        #[derive(Debug)]
+        pub struct #collection_name;
+        impl crate::types::Collection for #collection_name {
+            const NSID: &'static str = #nsid;
+            type Record = #module_name::Record;
+        }
+    }
+}
+
 fn lex_record(record: &LexRecord) -> Result<TokenStream> {
     let LexRecordRecord::Object(object) = &record.record;
     lex_object(object, "Record")


### PR DESCRIPTION
This makes operating over collections of records (such as in the repository format) easier, binding the collection NSID and record type together.