### PR TITLE
fix: Prevent panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,7 @@ dependencies = [
 name = "atrium-cli"
 version = "0.1.4"
 dependencies = [
+ "anyhow",
  "async-trait",
  "atrium-api",
  "atrium-xrpc-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,8 @@ isahc = "1.7.2"
 reqwest = { version = "0.11.24", default-features = false }
 
 # Errors
-anyhow = "1.0.71"
-thiserror = "1"
+anyhow = "1.0.80"
+thiserror = "1.0"
 
 # CLI
 clap = { version = "4.4.18", features = ["derive"] }

--- a/atrium-cli/Cargo.toml
+++ b/atrium-cli/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 keywords.workspace = true
 
 [dependencies]
+anyhow.workspace = true
 async-trait.workspace = true
 atrium-api.workspace = true
 atrium-xrpc-client.workspace = true

--- a/atrium-cli/src/bin/main.rs
+++ b/atrium-cli/src/bin/main.rs
@@ -18,9 +18,8 @@ struct Args {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = Args::parse();
-    Runner::new(args.pds_host, args.debug)
+    Ok(Runner::new(args.pds_host, args.debug)
         .await?
         .run(args.command)
-        .await;
-    Ok(())
+        .await?)
 }


### PR DESCRIPTION
Commands that use `handle` by default when `actor` is not specified (e.g. `get-profile`) were panicking when called without a user logged in.
Changed to use `anyhow` to catch errors in `Runner`.