### PR TITLE
feat: implement `std::fmt::Display` for all Error types

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,5 +2,7 @@ atrium-api/src/app.rs linguist-generated=true
 atrium-api/src/app/** linguist-generated=true
 atrium-api/src/com.rs linguist-generated=true
 atrium-api/src/com/** linguist-generated=true
+atrium-api/src/tools.rs linguist-generated=true
+atrium-api/src/tools/** linguist-generated=true
 atrium-api/src/client.rs linguist-generated=true
 atrium-api/src/records.rs linguist-generated=true

--- a/atrium-api/src/app/bsky/actor/get_preferences.rs
+++ b/atrium-api/src/app/bsky/actor/get_preferences.rs
@@ -11,3 +11,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/actor/get_profile.rs
+++ b/atrium-api/src/app/bsky/actor/get_profile.rs
@@ -10,3 +10,11 @@ pub type Output = crate::app::bsky::actor::defs::ProfileViewDetailed;
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/actor/get_profiles.rs
+++ b/atrium-api/src/app/bsky/actor/get_profiles.rs
@@ -13,3 +13,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/actor/get_suggestions.rs
+++ b/atrium-api/src/app/bsky/actor/get_suggestions.rs
@@ -18,3 +18,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/actor/put_preferences.rs
+++ b/atrium-api/src/app/bsky/actor/put_preferences.rs
@@ -8,3 +8,11 @@ pub struct Input {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/actor/search_actors.rs
+++ b/atrium-api/src/app/bsky/actor/search_actors.rs
@@ -24,3 +24,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/actor/search_actors_typeahead.rs
+++ b/atrium-api/src/app/bsky/actor/search_actors_typeahead.rs
@@ -20,3 +20,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/feed/describe_feed_generator.rs
+++ b/atrium-api/src/app/bsky/feed/describe_feed_generator.rs
@@ -11,6 +11,14 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Feed {

--- a/atrium-api/src/app/bsky/feed/get_actor_feeds.rs
+++ b/atrium-api/src/app/bsky/feed/get_actor_feeds.rs
@@ -19,3 +19,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/feed/get_actor_likes.rs
+++ b/atrium-api/src/app/bsky/feed/get_actor_likes.rs
@@ -22,3 +22,22 @@ pub enum Error {
     BlockedActor(Option<String>),
     BlockedByActor(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::BlockedActor(msg) => {
+                write!(_f, "BlockedActor")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+            Error::BlockedByActor(msg) => {
+                write!(_f, "BlockedByActor")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/feed/get_author_feed.rs
+++ b/atrium-api/src/app/bsky/feed/get_author_feed.rs
@@ -25,3 +25,22 @@ pub enum Error {
     BlockedActor(Option<String>),
     BlockedByActor(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::BlockedActor(msg) => {
+                write!(_f, "BlockedActor")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+            Error::BlockedByActor(msg) => {
+                write!(_f, "BlockedByActor")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/feed/get_feed.rs
+++ b/atrium-api/src/app/bsky/feed/get_feed.rs
@@ -21,3 +21,16 @@ pub struct Output {
 pub enum Error {
     UnknownFeed(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::UnknownFeed(msg) => {
+                write!(_f, "UnknownFeed")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/feed/get_feed_generator.rs
+++ b/atrium-api/src/app/bsky/feed/get_feed_generator.rs
@@ -18,3 +18,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/feed/get_feed_generators.rs
+++ b/atrium-api/src/app/bsky/feed/get_feed_generators.rs
@@ -13,3 +13,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/feed/get_feed_skeleton.rs
+++ b/atrium-api/src/app/bsky/feed/get_feed_skeleton.rs
@@ -22,3 +22,16 @@ pub struct Output {
 pub enum Error {
     UnknownFeed(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::UnknownFeed(msg) => {
+                write!(_f, "UnknownFeed")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/feed/get_likes.rs
+++ b/atrium-api/src/app/bsky/feed/get_likes.rs
@@ -26,6 +26,14 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Like {

--- a/atrium-api/src/app/bsky/feed/get_list_feed.rs
+++ b/atrium-api/src/app/bsky/feed/get_list_feed.rs
@@ -22,3 +22,16 @@ pub struct Output {
 pub enum Error {
     UnknownList(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::UnknownList(msg) => {
+                write!(_f, "UnknownList")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/feed/get_post_thread.rs
+++ b/atrium-api/src/app/bsky/feed/get_post_thread.rs
@@ -22,6 +22,19 @@ pub struct Output {
 pub enum Error {
     NotFound(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::NotFound(msg) => {
+                write!(_f, "NotFound")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "$type")]
 pub enum OutputThreadEnum {

--- a/atrium-api/src/app/bsky/feed/get_posts.rs
+++ b/atrium-api/src/app/bsky/feed/get_posts.rs
@@ -14,3 +14,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/feed/get_reposted_by.rs
+++ b/atrium-api/src/app/bsky/feed/get_reposted_by.rs
@@ -26,3 +26,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/feed/get_suggested_feeds.rs
+++ b/atrium-api/src/app/bsky/feed/get_suggested_feeds.rs
@@ -18,3 +18,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/feed/get_timeline.rs
+++ b/atrium-api/src/app/bsky/feed/get_timeline.rs
@@ -21,3 +21,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/feed/search_posts.rs
+++ b/atrium-api/src/app/bsky/feed/search_posts.rs
@@ -26,3 +26,16 @@ pub struct Output {
 pub enum Error {
     BadQueryString(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::BadQueryString(msg) => {
+                write!(_f, "BadQueryString")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/graph/get_blocks.rs
+++ b/atrium-api/src/app/bsky/graph/get_blocks.rs
@@ -18,3 +18,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/graph/get_followers.rs
+++ b/atrium-api/src/app/bsky/graph/get_followers.rs
@@ -20,3 +20,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/graph/get_follows.rs
+++ b/atrium-api/src/app/bsky/graph/get_follows.rs
@@ -20,3 +20,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/graph/get_list.rs
+++ b/atrium-api/src/app/bsky/graph/get_list.rs
@@ -21,3 +21,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/graph/get_list_blocks.rs
+++ b/atrium-api/src/app/bsky/graph/get_list_blocks.rs
@@ -18,3 +18,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/graph/get_list_mutes.rs
+++ b/atrium-api/src/app/bsky/graph/get_list_mutes.rs
@@ -18,3 +18,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/graph/get_lists.rs
+++ b/atrium-api/src/app/bsky/graph/get_lists.rs
@@ -20,3 +20,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/graph/get_mutes.rs
+++ b/atrium-api/src/app/bsky/graph/get_mutes.rs
@@ -18,3 +18,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/graph/get_relationships.rs
+++ b/atrium-api/src/app/bsky/graph/get_relationships.rs
@@ -22,6 +22,19 @@ pub enum Error {
     ///the primary actor at-identifier could not be resolved
     ActorNotFound(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::ActorNotFound(msg) => {
+                write!(_f, "ActorNotFound")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "$type")]
 pub enum OutputRelationshipsItem {

--- a/atrium-api/src/app/bsky/graph/get_suggested_follows_by_actor.rs
+++ b/atrium-api/src/app/bsky/graph/get_suggested_follows_by_actor.rs
@@ -13,3 +13,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/graph/mute_actor.rs
+++ b/atrium-api/src/app/bsky/graph/mute_actor.rs
@@ -8,3 +8,11 @@ pub struct Input {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/graph/mute_actor_list.rs
+++ b/atrium-api/src/app/bsky/graph/mute_actor_list.rs
@@ -8,3 +8,11 @@ pub struct Input {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/graph/unmute_actor.rs
+++ b/atrium-api/src/app/bsky/graph/unmute_actor.rs
@@ -8,3 +8,11 @@ pub struct Input {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/graph/unmute_actor_list.rs
+++ b/atrium-api/src/app/bsky/graph/unmute_actor_list.rs
@@ -8,3 +8,11 @@ pub struct Input {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/labeler/get_services.rs
+++ b/atrium-api/src/app/bsky/labeler/get_services.rs
@@ -15,6 +15,14 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "$type")]
 pub enum OutputViewsItem {

--- a/atrium-api/src/app/bsky/notification/get_unread_count.rs
+++ b/atrium-api/src/app/bsky/notification/get_unread_count.rs
@@ -14,3 +14,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/notification/list_notifications.rs
+++ b/atrium-api/src/app/bsky/notification/list_notifications.rs
@@ -22,6 +22,14 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Notification {

--- a/atrium-api/src/app/bsky/notification/register_push.rs
+++ b/atrium-api/src/app/bsky/notification/register_push.rs
@@ -11,3 +11,11 @@ pub struct Input {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/notification/update_seen.rs
+++ b/atrium-api/src/app/bsky/notification/update_seen.rs
@@ -8,3 +8,11 @@ pub struct Input {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/unspecced/get_popular_feed_generators.rs
+++ b/atrium-api/src/app/bsky/unspecced/get_popular_feed_generators.rs
@@ -20,3 +20,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/unspecced/get_tagged_suggestions.rs
+++ b/atrium-api/src/app/bsky/unspecced/get_tagged_suggestions.rs
@@ -11,6 +11,14 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Suggestion {

--- a/atrium-api/src/app/bsky/unspecced/search_actors_skeleton.rs
+++ b/atrium-api/src/app/bsky/unspecced/search_actors_skeleton.rs
@@ -29,3 +29,16 @@ pub struct Output {
 pub enum Error {
     BadQueryString(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::BadQueryString(msg) => {
+                write!(_f, "BadQueryString")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/app/bsky/unspecced/search_posts_skeleton.rs
+++ b/atrium-api/src/app/bsky/unspecced/search_posts_skeleton.rs
@@ -26,3 +26,16 @@ pub struct Output {
 pub enum Error {
     BadQueryString(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::BadQueryString(msg) => {
+                write!(_f, "BadQueryString")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/admin/delete_account.rs
+++ b/atrium-api/src/com/atproto/admin/delete_account.rs
@@ -8,3 +8,11 @@ pub struct Input {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/admin/disable_account_invites.rs
+++ b/atrium-api/src/com/atproto/admin/disable_account_invites.rs
@@ -11,3 +11,11 @@ pub struct Input {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/admin/disable_invite_codes.rs
+++ b/atrium-api/src/com/atproto/admin/disable_invite_codes.rs
@@ -11,3 +11,11 @@ pub struct Input {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/admin/enable_account_invites.rs
+++ b/atrium-api/src/com/atproto/admin/enable_account_invites.rs
@@ -11,3 +11,11 @@ pub struct Input {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/admin/get_account_info.rs
+++ b/atrium-api/src/com/atproto/admin/get_account_info.rs
@@ -9,3 +9,11 @@ pub type Output = crate::com::atproto::admin::defs::AccountView;
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/admin/get_account_infos.rs
+++ b/atrium-api/src/com/atproto/admin/get_account_infos.rs
@@ -13,3 +13,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/admin/get_invite_codes.rs
+++ b/atrium-api/src/com/atproto/admin/get_invite_codes.rs
@@ -20,3 +20,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/admin/get_subject_status.rs
+++ b/atrium-api/src/com/atproto/admin/get_subject_status.rs
@@ -20,6 +20,14 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "$type")]
 pub enum OutputSubjectEnum {

--- a/atrium-api/src/com/atproto/admin/send_email.rs
+++ b/atrium-api/src/com/atproto/admin/send_email.rs
@@ -20,3 +20,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/admin/update_account_email.rs
+++ b/atrium-api/src/com/atproto/admin/update_account_email.rs
@@ -10,3 +10,11 @@ pub struct Input {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/admin/update_account_handle.rs
+++ b/atrium-api/src/com/atproto/admin/update_account_handle.rs
@@ -9,3 +9,11 @@ pub struct Input {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/admin/update_account_password.rs
+++ b/atrium-api/src/com/atproto/admin/update_account_password.rs
@@ -9,3 +9,11 @@ pub struct Input {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/admin/update_subject_status.rs
+++ b/atrium-api/src/com/atproto/admin/update_subject_status.rs
@@ -17,6 +17,14 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "$type")]
 pub enum InputSubjectEnum {

--- a/atrium-api/src/com/atproto/identity/get_recommended_did_credentials.rs
+++ b/atrium-api/src/com/atproto/identity/get_recommended_did_credentials.rs
@@ -16,3 +16,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/identity/request_plc_operation_signature.rs
+++ b/atrium-api/src/com/atproto/identity/request_plc_operation_signature.rs
@@ -3,3 +3,11 @@
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/identity/resolve_handle.rs
+++ b/atrium-api/src/com/atproto/identity/resolve_handle.rs
@@ -14,3 +14,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/identity/sign_plc_operation.rs
+++ b/atrium-api/src/com/atproto/identity/sign_plc_operation.rs
@@ -24,3 +24,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/identity/submit_plc_operation.rs
+++ b/atrium-api/src/com/atproto/identity/submit_plc_operation.rs
@@ -8,3 +8,11 @@ pub struct Input {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/identity/update_handle.rs
+++ b/atrium-api/src/com/atproto/identity/update_handle.rs
@@ -9,3 +9,11 @@ pub struct Input {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/label/query_labels.rs
+++ b/atrium-api/src/com/atproto/label/query_labels.rs
@@ -23,3 +23,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/label/subscribe_labels.rs
+++ b/atrium-api/src/com/atproto/label/subscribe_labels.rs
@@ -13,6 +13,19 @@ pub struct Parameters {
 pub enum Error {
     FutureCursor(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::FutureCursor(msg) => {
+                write!(_f, "FutureCursor")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Info {

--- a/atrium-api/src/com/atproto/moderation/create_report.rs
+++ b/atrium-api/src/com/atproto/moderation/create_report.rs
@@ -24,6 +24,14 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "$type")]
 pub enum InputSubjectEnum {

--- a/atrium-api/src/com/atproto/repo/apply_writes.rs
+++ b/atrium-api/src/com/atproto/repo/apply_writes.rs
@@ -19,6 +19,19 @@ pub enum Error {
     ///Indicates that the 'swapCommit' parameter did not match current commit.
     InvalidSwap(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::InvalidSwap(msg) => {
+                write!(_f, "InvalidSwap")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
 ///Operation which creates a new record.
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]

--- a/atrium-api/src/com/atproto/repo/create_record.rs
+++ b/atrium-api/src/com/atproto/repo/create_record.rs
@@ -31,3 +31,16 @@ pub enum Error {
     ///Indicates that 'swapCommit' didn't match current repo commit.
     InvalidSwap(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::InvalidSwap(msg) => {
+                write!(_f, "InvalidSwap")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/repo/delete_record.rs
+++ b/atrium-api/src/com/atproto/repo/delete_record.rs
@@ -21,3 +21,16 @@ pub struct Input {
 pub enum Error {
     InvalidSwap(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::InvalidSwap(msg) => {
+                write!(_f, "InvalidSwap")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/repo/describe_repo.rs
+++ b/atrium-api/src/com/atproto/repo/describe_repo.rs
@@ -21,3 +21,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/repo/get_record.rs
+++ b/atrium-api/src/com/atproto/repo/get_record.rs
@@ -24,3 +24,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/repo/import_repo.rs
+++ b/atrium-api/src/com/atproto/repo/import_repo.rs
@@ -3,3 +3,11 @@
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/repo/list_missing_blobs.rs
+++ b/atrium-api/src/com/atproto/repo/list_missing_blobs.rs
@@ -18,6 +18,14 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct RecordBlob {

--- a/atrium-api/src/com/atproto/repo/list_records.rs
+++ b/atrium-api/src/com/atproto/repo/list_records.rs
@@ -32,6 +32,14 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Record {

--- a/atrium-api/src/com/atproto/repo/put_record.rs
+++ b/atrium-api/src/com/atproto/repo/put_record.rs
@@ -32,3 +32,16 @@ pub struct Output {
 pub enum Error {
     InvalidSwap(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::InvalidSwap(msg) => {
+                write!(_f, "InvalidSwap")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/repo/upload_blob.rs
+++ b/atrium-api/src/com/atproto/repo/upload_blob.rs
@@ -8,3 +8,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/server/activate_account.rs
+++ b/atrium-api/src/com/atproto/server/activate_account.rs
@@ -3,3 +3,11 @@
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/server/check_account_status.rs
+++ b/atrium-api/src/com/atproto/server/check_account_status.rs
@@ -16,3 +16,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/server/confirm_email.rs
+++ b/atrium-api/src/com/atproto/server/confirm_email.rs
@@ -14,3 +14,34 @@ pub enum Error {
     InvalidToken(Option<String>),
     InvalidEmail(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::AccountNotFound(msg) => {
+                write!(_f, "AccountNotFound")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+            Error::ExpiredToken(msg) => {
+                write!(_f, "ExpiredToken")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+            Error::InvalidToken(msg) => {
+                write!(_f, "InvalidToken")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+            Error::InvalidEmail(msg) => {
+                write!(_f, "InvalidEmail")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/server/create_account.rs
+++ b/atrium-api/src/com/atproto/server/create_account.rs
@@ -50,3 +50,52 @@ pub enum Error {
     UnresolvableDid(Option<String>),
     IncompatibleDidDoc(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::InvalidHandle(msg) => {
+                write!(_f, "InvalidHandle")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+            Error::InvalidPassword(msg) => {
+                write!(_f, "InvalidPassword")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+            Error::InvalidInviteCode(msg) => {
+                write!(_f, "InvalidInviteCode")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+            Error::HandleNotAvailable(msg) => {
+                write!(_f, "HandleNotAvailable")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+            Error::UnsupportedDomain(msg) => {
+                write!(_f, "UnsupportedDomain")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+            Error::UnresolvableDid(msg) => {
+                write!(_f, "UnresolvableDid")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+            Error::IncompatibleDidDoc(msg) => {
+                write!(_f, "IncompatibleDidDoc")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/server/create_app_password.rs
+++ b/atrium-api/src/com/atproto/server/create_app_password.rs
@@ -12,6 +12,19 @@ pub type Output = AppPassword;
 pub enum Error {
     AccountTakedown(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::AccountTakedown(msg) => {
+                write!(_f, "AccountTakedown")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct AppPassword {

--- a/atrium-api/src/com/atproto/server/create_invite_code.rs
+++ b/atrium-api/src/com/atproto/server/create_invite_code.rs
@@ -15,3 +15,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/server/create_invite_codes.rs
+++ b/atrium-api/src/com/atproto/server/create_invite_codes.rs
@@ -16,6 +16,14 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountCodes {

--- a/atrium-api/src/com/atproto/server/create_session.rs
+++ b/atrium-api/src/com/atproto/server/create_session.rs
@@ -26,3 +26,16 @@ pub struct Output {
 pub enum Error {
     AccountTakedown(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::AccountTakedown(msg) => {
+                write!(_f, "AccountTakedown")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/server/deactivate_account.rs
+++ b/atrium-api/src/com/atproto/server/deactivate_account.rs
@@ -10,3 +10,11 @@ pub struct Input {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/server/delete_account.rs
+++ b/atrium-api/src/com/atproto/server/delete_account.rs
@@ -13,3 +13,22 @@ pub enum Error {
     ExpiredToken(Option<String>),
     InvalidToken(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::ExpiredToken(msg) => {
+                write!(_f, "ExpiredToken")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+            Error::InvalidToken(msg) => {
+                write!(_f, "InvalidToken")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/server/delete_session.rs
+++ b/atrium-api/src/com/atproto/server/delete_session.rs
@@ -3,3 +3,11 @@
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/server/describe_server.rs
+++ b/atrium-api/src/com/atproto/server/describe_server.rs
@@ -22,6 +22,14 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Contact {

--- a/atrium-api/src/com/atproto/server/get_account_invite_codes.rs
+++ b/atrium-api/src/com/atproto/server/get_account_invite_codes.rs
@@ -19,3 +19,16 @@ pub struct Output {
 pub enum Error {
     DuplicateCreate(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::DuplicateCreate(msg) => {
+                write!(_f, "DuplicateCreate")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/server/get_service_auth.rs
+++ b/atrium-api/src/com/atproto/server/get_service_auth.rs
@@ -14,3 +14,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/server/get_session.rs
+++ b/atrium-api/src/com/atproto/server/get_session.rs
@@ -15,3 +15,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/server/list_app_passwords.rs
+++ b/atrium-api/src/com/atproto/server/list_app_passwords.rs
@@ -10,6 +10,19 @@ pub struct Output {
 pub enum Error {
     AccountTakedown(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::AccountTakedown(msg) => {
+                write!(_f, "AccountTakedown")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct AppPassword {

--- a/atrium-api/src/com/atproto/server/refresh_session.rs
+++ b/atrium-api/src/com/atproto/server/refresh_session.rs
@@ -15,3 +15,16 @@ pub struct Output {
 pub enum Error {
     AccountTakedown(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::AccountTakedown(msg) => {
+                write!(_f, "AccountTakedown")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/server/request_account_delete.rs
+++ b/atrium-api/src/com/atproto/server/request_account_delete.rs
@@ -3,3 +3,11 @@
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/server/request_email_confirmation.rs
+++ b/atrium-api/src/com/atproto/server/request_email_confirmation.rs
@@ -3,3 +3,11 @@
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/server/request_email_update.rs
+++ b/atrium-api/src/com/atproto/server/request_email_update.rs
@@ -8,3 +8,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/server/request_password_reset.rs
+++ b/atrium-api/src/com/atproto/server/request_password_reset.rs
@@ -8,3 +8,11 @@ pub struct Input {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/server/reserve_signing_key.rs
+++ b/atrium-api/src/com/atproto/server/reserve_signing_key.rs
@@ -16,3 +16,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/server/reset_password.rs
+++ b/atrium-api/src/com/atproto/server/reset_password.rs
@@ -12,3 +12,22 @@ pub enum Error {
     ExpiredToken(Option<String>),
     InvalidToken(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::ExpiredToken(msg) => {
+                write!(_f, "ExpiredToken")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+            Error::InvalidToken(msg) => {
+                write!(_f, "InvalidToken")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/server/revoke_app_password.rs
+++ b/atrium-api/src/com/atproto/server/revoke_app_password.rs
@@ -8,3 +8,11 @@ pub struct Input {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/server/update_email.rs
+++ b/atrium-api/src/com/atproto/server/update_email.rs
@@ -15,3 +15,28 @@ pub enum Error {
     InvalidToken(Option<String>),
     TokenRequired(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::ExpiredToken(msg) => {
+                write!(_f, "ExpiredToken")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+            Error::InvalidToken(msg) => {
+                write!(_f, "InvalidToken")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+            Error::TokenRequired(msg) => {
+                write!(_f, "TokenRequired")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/sync/get_blob.rs
+++ b/atrium-api/src/com/atproto/sync/get_blob.rs
@@ -11,3 +11,11 @@ pub struct Parameters {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/sync/get_blocks.rs
+++ b/atrium-api/src/com/atproto/sync/get_blocks.rs
@@ -10,3 +10,11 @@ pub struct Parameters {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/sync/get_checkout.rs
+++ b/atrium-api/src/com/atproto/sync/get_checkout.rs
@@ -9,3 +9,11 @@ pub struct Parameters {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/sync/get_head.rs
+++ b/atrium-api/src/com/atproto/sync/get_head.rs
@@ -16,3 +16,16 @@ pub struct Output {
 pub enum Error {
     HeadNotFound(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::HeadNotFound(msg) => {
+                write!(_f, "HeadNotFound")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/sync/get_latest_commit.rs
+++ b/atrium-api/src/com/atproto/sync/get_latest_commit.rs
@@ -17,3 +17,16 @@ pub struct Output {
 pub enum Error {
     RepoNotFound(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::RepoNotFound(msg) => {
+                write!(_f, "RepoNotFound")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/sync/get_record.rs
+++ b/atrium-api/src/com/atproto/sync/get_record.rs
@@ -15,3 +15,11 @@ pub struct Parameters {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/sync/get_repo.rs
+++ b/atrium-api/src/com/atproto/sync/get_repo.rs
@@ -12,3 +12,11 @@ pub struct Parameters {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/sync/list_blobs.rs
+++ b/atrium-api/src/com/atproto/sync/list_blobs.rs
@@ -23,3 +23,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/sync/list_repos.rs
+++ b/atrium-api/src/com/atproto/sync/list_repos.rs
@@ -18,6 +18,14 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Repo {

--- a/atrium-api/src/com/atproto/sync/notify_of_update.rs
+++ b/atrium-api/src/com/atproto/sync/notify_of_update.rs
@@ -9,3 +9,11 @@ pub struct Input {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/sync/request_crawl.rs
+++ b/atrium-api/src/com/atproto/sync/request_crawl.rs
@@ -9,3 +9,11 @@ pub struct Input {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/sync/subscribe_repos.rs
+++ b/atrium-api/src/com/atproto/sync/subscribe_repos.rs
@@ -15,6 +15,25 @@ pub enum Error {
     ///If the consumer of the stream can not keep up with events, and a backlog gets too large, the server will drop the connection.
     ConsumerTooSlow(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::FutureCursor(msg) => {
+                write!(_f, "FutureCursor")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+            Error::ConsumerTooSlow(msg) => {
+                write!(_f, "ConsumerTooSlow")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
 ///Represents an update of repository state. Note that empty commits are allowed, which include no repo data changes, but an update to rev and signature.
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]

--- a/atrium-api/src/com/atproto/temp/check_signup_queue.rs
+++ b/atrium-api/src/com/atproto/temp/check_signup_queue.rs
@@ -12,3 +12,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/temp/fetch_labels.rs
+++ b/atrium-api/src/com/atproto/temp/fetch_labels.rs
@@ -16,3 +16,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/com/atproto/temp/request_phone_verification.rs
+++ b/atrium-api/src/com/atproto/temp/request_phone_verification.rs
@@ -8,3 +8,11 @@ pub struct Input {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/tools/ozone/communication/create_template.rs
+++ b/atrium-api/src/tools/ozone/communication/create_template.rs
@@ -17,3 +17,11 @@ pub type Output = crate::tools::ozone::communication::defs::TemplateView;
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/tools/ozone/communication/delete_template.rs
+++ b/atrium-api/src/tools/ozone/communication/delete_template.rs
@@ -8,3 +8,11 @@ pub struct Input {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/tools/ozone/communication/list_templates.rs
+++ b/atrium-api/src/tools/ozone/communication/list_templates.rs
@@ -10,3 +10,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/tools/ozone/communication/update_template.rs
+++ b/atrium-api/src/tools/ozone/communication/update_template.rs
@@ -24,3 +24,11 @@ pub type Output = crate::tools::ozone::communication::defs::TemplateView;
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/tools/ozone/moderation/emit_event.rs
+++ b/atrium-api/src/tools/ozone/moderation/emit_event.rs
@@ -15,6 +15,19 @@ pub type Output = crate::tools::ozone::moderation::defs::ModEventView;
 pub enum Error {
     SubjectHasAction(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::SubjectHasAction(msg) => {
+                write!(_f, "SubjectHasAction")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "$type")]
 pub enum InputEventEnum {

--- a/atrium-api/src/tools/ozone/moderation/get_event.rs
+++ b/atrium-api/src/tools/ozone/moderation/get_event.rs
@@ -9,3 +9,11 @@ pub type Output = crate::tools::ozone::moderation::defs::ModEventViewDetail;
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/tools/ozone/moderation/get_record.rs
+++ b/atrium-api/src/tools/ozone/moderation/get_record.rs
@@ -13,3 +13,16 @@ pub type Output = crate::tools::ozone::moderation::defs::RecordViewDetail;
 pub enum Error {
     RecordNotFound(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::RecordNotFound(msg) => {
+                write!(_f, "RecordNotFound")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/tools/ozone/moderation/get_repo.rs
+++ b/atrium-api/src/tools/ozone/moderation/get_repo.rs
@@ -11,3 +11,16 @@ pub type Output = crate::tools::ozone::moderation::defs::RepoViewDetail;
 pub enum Error {
     RepoNotFound(Option<String>),
 }
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::RepoNotFound(msg) => {
+                write!(_f, "RepoNotFound")?;
+                if let Some(msg) = msg {
+                    write!(_f, ": {msg}")?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/tools/ozone/moderation/query_events.rs
+++ b/atrium-api/src/tools/ozone/moderation/query_events.rs
@@ -57,3 +57,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/tools/ozone/moderation/query_statuses.rs
+++ b/atrium-api/src/tools/ozone/moderation/query_statuses.rs
@@ -60,3 +60,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/atrium-api/src/tools/ozone/moderation/search_repos.rs
+++ b/atrium-api/src/tools/ozone/moderation/search_repos.rs
@@ -23,3 +23,11 @@ pub struct Output {
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "error", content = "message")]
 pub enum Error {}
+impl std::fmt::Display for Error {
+    fn fmt(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/lexicon/atrium-codegen/src/generator.rs
+++ b/lexicon/atrium-codegen/src/generator.rs
@@ -175,7 +175,10 @@ pub(crate) fn generate_modules(
                 vec![],
             )
         } else if let Ok(relative) = path.as_ref().strip_prefix(outdir) {
-            let ns = relative.to_string_lossy().replace('/', ".");
+            let ns = relative
+                .to_string_lossy()
+                .replace('/', ".")
+                .replace('\\', ".");
             let doc = format!("Definitions for the `{}` namespace.", ns);
 
             let collections = names


### PR DESCRIPTION
This PR makes it easier for projects that use the atrium_api to create easy-to-read error messages.