### PR TITLE
feat: Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,8 +136,8 @@ dependencies = [
  "chrono",
  "futures",
  "http",
+ "ipld-core",
  "langtag",
- "libipld-core",
  "regex",
  "serde",
  "serde_bytes",
@@ -294,16 +294,16 @@ dependencies = [
 
 [[package]]
 name = "cid"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd94671561e36e4e7de75f753f577edafb0e7c05d6e4547229fdf7938fbcd2c3"
+checksum = "3147d8272e8fa0ccd29ce51194dd98f79ddfb8191ba9e3409884e751798acf3a"
 dependencies = [
  "core2",
  "multibase",
  "multihash",
  "serde",
  "serde_bytes",
- "unsigned-varint",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -863,6 +863,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipld-core"
+version = "0.3.2"
+source = "git+https://github.com/ipld/rust-ipld-core?branch=codec-feature-flag#86b62baef68b03eed30f17ceb0aff6f08e8bc25e"
+dependencies = [
+ "cid",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,21 +951,6 @@ name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
-
-[[package]]
-name = "libipld-core"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5acd707e8d8b092e967b2af978ed84709eaded82b75effe6cb6f6cc797ef8158"
-dependencies = [
- "anyhow",
- "cid",
- "core2",
- "multibase",
- "multihash",
- "serde",
- "thiserror",
-]
 
 [[package]]
 name = "libnghttp2-sys"
@@ -1076,29 +1071,13 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.18.1"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd8a792c1694c6da4f68db0a9d707c72bd260994da179e6030a5dcee00bb815"
+checksum = "076d548d76a0e2a0d4ab471d0b1c36c577786dfc4471242035d97a12a735c492"
 dependencies = [
  "core2",
- "multihash-derive",
  "serde",
- "serde-big-array",
- "unsigned-varint",
-]
-
-[[package]]
-name = "multihash-derive"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6d4752e6230d8ef7adf7bd5d8c4b1f6561c1014c5ba9a37445ccefe18aa1db"
-dependencies = [
- "proc-macro-crate",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "synstructure",
+ "unsigned-varint 0.7.2",
 ]
 
 [[package]]
@@ -1297,40 +1276,6 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
-
-[[package]]
-name = "proc-macro-crate"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
-dependencies = [
- "thiserror",
- "toml",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -1608,15 +1553,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-big-array"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd31f59f6fe2b0c055371bb2f16d7f0aa7d8881676c04a55b1596d1a17cd10a4"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_bytes"
 version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,11 +1574,11 @@ dependencies = [
 
 [[package]]
 name = "serde_ipld_dagcbor"
-version = "0.4.2"
-source = "git+https://github.com/sugyan/serde_ipld_dagcbor.git?rev=345b240#345b240b032e8d934dd726478e34902e1272fc3c"
+version = "0.5.0"
+source = "git+https://github.com/ipld/serde_ipld_dagcbor?branch=codec-feature-flag#2536b54d612971cc8666d9ca7319cc800e482bff"
 dependencies = [
  "cbor4ii",
- "cid",
+ "ipld-core",
  "scopeguard",
  "serde",
 ]
@@ -1771,18 +1707,6 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
-]
 
 [[package]]
 name = "system-configuration"
@@ -1917,15 +1841,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2001,16 +1916,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
 name = "unsigned-varint"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
+
+[[package]]
+name = "unsigned-varint"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
 
 [[package]]
 name = "untrusted"
@@ -2040,12 +1955,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "waker-fn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,8 +864,9 @@ dependencies = [
 
 [[package]]
 name = "ipld-core"
-version = "0.3.2"
-source = "git+https://github.com/ipld/rust-ipld-core?branch=codec-feature-flag#86b62baef68b03eed30f17ceb0aff6f08e8bc25e"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cd30b9d3019be78818b8d20691ecfa98630ae2d7fb23ffd4d668ee27ad25108"
 dependencies = [
  "cid",
  "serde",
@@ -1574,8 +1575,9 @@ dependencies = [
 
 [[package]]
 name = "serde_ipld_dagcbor"
-version = "0.5.0"
-source = "git+https://github.com/ipld/serde_ipld_dagcbor?branch=codec-feature-flag#2536b54d612971cc8666d9ca7319cc800e482bff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb1eedfc9e48051a90d79e189dea2303b7c0df82f03e154ae85bf2ceea957972"
 dependencies = [
  "cbor4ii",
  "ipld-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ atrium-xrpc-client = { version = "0.5.0", path = "atrium-xrpc-client" }
 async-trait = "0.1.68"
 
 # DAG-CBOR codec
-ipld-core = { version = "0.3.2", default-features = false, features = ["std"] }
-serde_ipld_dagcbor = { versin = "0.5.0", default-features = false, features = ["std"] }
+ipld-core = { version = "0.4.0", default-features = false, features = ["std"] }
+serde_ipld_dagcbor = { version = "0.6.0", default-features = false, features = ["std"] }
 
 # Parsing and validation
 chrono = "0.4"
@@ -64,7 +64,3 @@ mockito = "1.2"
 
 # WebAssembly
 wasm-bindgen-test = "0.3.41"
-
-[patch.crates-io]
-ipld-core = { git = "https://github.com/ipld/rust-ipld-core", branch = "codec-feature-flag" }
-serde_ipld_dagcbor = { git = "https://github.com/ipld/serde_ipld_dagcbor", branch = "codec-feature-flag" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,9 @@ atrium-xrpc-client = { version = "0.5.0", path = "atrium-xrpc-client" }
 # Can be removed once MSRV is at least 1.75.0.
 async-trait = "0.1.68"
 
-# DAG-CBOR codec and CAR format
-libipld-core = "0.16"
+# DAG-CBOR codec
+ipld-core = { version = "0.3.2", default-features = false, features = ["std"] }
+serde_ipld_dagcbor = { versin = "0.5.0", default-features = false, features = ["std"] }
 
 # Parsing and validation
 chrono = "0.4"
@@ -63,3 +64,7 @@ mockito = "1.2"
 
 # WebAssembly
 wasm-bindgen-test = "0.3.41"
+
+[patch.crates-io]
+ipld-core = { git = "https://github.com/ipld/rust-ipld-core", branch = "codec-feature-flag" }
+serde_ipld_dagcbor = { git = "https://github.com/ipld/serde_ipld_dagcbor", branch = "codec-feature-flag" }

--- a/atrium-api/Cargo.toml
+++ b/atrium-api/Cargo.toml
@@ -16,8 +16,8 @@ atrium-xrpc.workspace = true
 async-trait.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 http.workspace = true
+ipld-core.workspace = true
 langtag = { workspace = true, features = ["serde"] }
-libipld-core = { workspace = true, features = ["serde-codec"] }
 regex.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_bytes.workspace = true
@@ -30,7 +30,7 @@ agent = ["tokio/sync"]
 [dev-dependencies]
 futures.workspace = true
 serde_json.workspace = true
-serde_ipld_dagcbor = { git = "https://github.com/sugyan/serde_ipld_dagcbor.git", rev = "345b240" }
+serde_ipld_dagcbor.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }

--- a/atrium-api/Cargo.toml
+++ b/atrium-api/Cargo.toml
@@ -16,7 +16,7 @@ atrium-xrpc.workspace = true
 async-trait.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 http.workspace = true
-ipld-core.workspace = true
+ipld-core = { workspace = true, features = ["serde"] }
 langtag = { workspace = true, features = ["serde"] }
 regex.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/atrium-api/src/types/cid_link.rs
+++ b/atrium-api/src/types/cid_link.rs
@@ -1,5 +1,5 @@
-use libipld_core::cid::{Cid, Error};
-use libipld_core::ipld::Ipld;
+use ipld_core::cid::{Cid, Error};
+use ipld_core::ipld::Ipld;
 use serde::{Deserialize, Serialize};
 
 /// Representation of an IPLD Link.

--- a/atrium-api/src/types/string.rs
+++ b/atrium-api/src/types/string.rs
@@ -3,8 +3,8 @@
 //! [string formats]: https://atproto.com/specs/lexicon#string-formats
 
 use chrono::DurationRound;
+use ipld_core::cid;
 use langtag::{LanguageTag, LanguageTagBuf};
-use libipld_core::cid;
 use regex::Regex;
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 use std::{cell::OnceCell, cmp, ops::Deref, str::FromStr};

--- a/examples/firehose/Cargo.toml
+++ b/examples/firehose/Cargo.toml
@@ -10,9 +10,13 @@ anyhow = "1.0.80"
 atrium-api = { version = "0.18.1", features = ["dag-cbor"] }
 chrono = "0.4.34"
 futures = "0.3.30"
-ipld-core = { version = "0.2.0", features = ["serde"] }
+ipld-core = { version = "0.3.2", default-features = false, features = ["std"] }
 rs-car = "0.4.1"
-serde_ipld_dagcbor = { git = "https://github.com/ipld/serde_ipld_dagcbor.git", rev = "297a6c26c8c89807e6602cab9803ef2c4ae8b459" }
+serde_ipld_dagcbor = { versin = "0.5.0", default-features = false, features = ["std"] }
 tokio = { version = "1.36.0", features = ["full"] }
 tokio-tungstenite = { version = "0.21.0", features = ["native-tls"] }
 trait-variant = "0.1.1"
+
+[patch.crates-io]
+ipld-core = { git = "https://github.com/ipld/rust-ipld-core", branch = "codec-feature-flag" }
+serde_ipld_dagcbor = { git = "https://github.com/ipld/serde_ipld_dagcbor", branch = "codec-feature-flag" }

--- a/examples/firehose/Cargo.toml
+++ b/examples/firehose/Cargo.toml
@@ -10,13 +10,9 @@ anyhow = "1.0.80"
 atrium-api = { version = "0.18.1", features = ["dag-cbor"] }
 chrono = "0.4.34"
 futures = "0.3.30"
-ipld-core = { version = "0.3.2", default-features = false, features = ["std"] }
+ipld-core = { version = "0.4.0", default-features = false, features = ["std"] }
 rs-car = "0.4.1"
-serde_ipld_dagcbor = { versin = "0.5.0", default-features = false, features = ["std"] }
+serde_ipld_dagcbor = { version = "0.6.0", default-features = false, features = ["std"] }
 tokio = { version = "1.36.0", features = ["full"] }
 tokio-tungstenite = { version = "0.21.0", features = ["native-tls"] }
 trait-variant = "0.1.1"
-
-[patch.crates-io]
-ipld-core = { git = "https://github.com/ipld/rust-ipld-core", branch = "codec-feature-flag" }
-serde_ipld_dagcbor = { git = "https://github.com/ipld/serde_ipld_dagcbor", branch = "codec-feature-flag" }


### PR DESCRIPTION
- Use `ipld-core` and `serde-ipld-dagcbor` with patched branches