### PR TITLE
feat: Replace serde_qs to serde_html_form

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,8 +171,8 @@ dependencies = [
  "async-trait",
  "http 1.1.0",
  "serde",
+ "serde_html_form",
  "serde_json",
- "serde_qs",
  "thiserror",
  "tokio",
  "wasm-bindgen-test",
@@ -1624,6 +1624,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_html_form"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de514ef58196f1fc96dcaef80fe6170a1ce6215df9687a93fe8300e773fefc5"
+dependencies = [
+ "form_urlencoded",
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_ipld_dagcbor"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1644,17 +1657,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_qs"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0431a35568651e363364210c91983c1da5eb29404d9f0928b67d4ebcfa7d330c"
-dependencies = [
- "percent-encoding",
- "serde",
- "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ regex = "1"
 serde = "1.0.160"
 serde_bytes = "0.11.9"
 serde_json = "1.0.96"
-serde_qs = "0.12"
+serde_html_form = "0.2.6"
 
 # Networking
 futures = { version = "0.3.30", default-features = false, features = ["alloc"] }

--- a/atrium-xrpc/Cargo.toml
+++ b/atrium-xrpc/Cargo.toml
@@ -15,8 +15,8 @@ keywords.workspace = true
 async-trait.workspace = true
 http.workspace = true
 serde = { workspace = true, features = ["derive"] }
+serde_html_form.workspace = true
 serde_json.workspace = true
-serde_qs.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/atrium-xrpc/src/error.rs
+++ b/atrium-xrpc/src/error.rs
@@ -78,8 +78,8 @@ pub enum Error<E> {
     HttpClient(Box<dyn std::error::Error + Send + Sync + 'static>),
     #[error("serde_json error: {0}")]
     SerdeJson(#[from] serde_json::Error),
-    #[error("serde_qs error: {0}")]
-    SerdeQs(#[from] serde_qs::Error),
+    #[error("serde_html_form error: {0}")]
+    SerdeHtmlForm(#[from] serde_html_form::ser::Error),
     #[error("unexpected response type")]
     UnexpectedResponseType,
 }

--- a/atrium-xrpc/src/lib.rs
+++ b/atrium-xrpc/src/lib.rs
@@ -73,7 +73,7 @@ pub trait XrpcClient: HttpClient {
     {
         let mut uri = format!("{}/xrpc/{}", self.base_uri(), request.path);
         if let Some(p) = &request.parameters {
-            serde_qs::to_string(p).map(|qs| {
+            serde_html_form::to_string(p).map(|qs| {
                 uri += "?";
                 uri += &qs;
             })?;


### PR DESCRIPTION
fixes #160 

`serde_qs` was introduced in #25, and it did indeed correctly serialize parameters, even those that contained arrays.
However, the serialized result is a format like `uris[0]=at%3A%2F%2Fdid%3A...&uris[1]=at%3A%2F%2Fdid%3A...`, and this behavior does not seem to be changeable.
Not that this format is wrong, but it seems to cause problems when used in requests to servers that work with [`express`](https://expressjs.com/), such as bluesky's appview.

Specifically, in the `qs` library used by express, if we specify an index larger than `20` by `[]` notation, it is treated as an object key, and the query in the request is not correctly passed as an array.
https://www.npmjs.com/package/qs#parsing-arrays

It would seem that this behavior could be avoided if it could be serialized with a format that does not include an index, such as `uris=at%3A%2F%2Fdid%3A...&uris=at%3A%2F%2Fdid%3A...`.
There is a crate called [`serde_html_form`](https://crates.io/crates/serde_html_form) that does exactly that and is [used in axum](https://github.com/tokio-rs/axum/pull/1031) and others.
Replacing `serde_qs` with this library would solve the problem.