### PR TITLE
api: Add `Datetime::as_str`

### DIFF
--- a/atrium-api/CHANGELOG.md
+++ b/atrium-api/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `atrium_api::types::string::Datetime::as_str`
+
 ## [0.24.3](https://github.com/sugyan/atrium/compare/atrium-api-v0.24.2...atrium-api-v0.24.3) - 2024-09-13
 
 ### Added

--- a/atrium-api/src/types/string.rs
+++ b/atrium-api/src/types/string.rs
@@ -195,6 +195,13 @@ impl Datetime {
         let serialized = dt.to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
         Self { serialized, dt }
     }
+
+    /// Extracts a string slice containing the entire `Datetime`.
+    #[inline]
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        self.serialized.as_str()
+    }
 }
 
 impl FromStr for Datetime {


### PR DESCRIPTION
The `AsRef` implementation exposes the `chrono::DateTime`, so we need a different API to expose the canonical serialized form. It can be accessed via `serde::Serialize` but that forces a copy which may be unnecessary in some situations.