### PR TITLE
Allow the specification of alt-text on images when using CLI.

### DIFF
--- a/bsky-cli/src/commands.rs
+++ b/bsky-cli/src/commands.rs
@@ -87,6 +87,9 @@ pub struct CreatePostArgs {
     /// Images to embed
     #[arg(short, long)]
     pub(crate) images: Vec<PathBuf>,
+    /// Alt-Text for images
+    #[arg(short, long)]
+    pub(crate) alt_text: Vec<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/bsky-cli/src/runner.rs
+++ b/bsky-cli/src/runner.rs
@@ -374,7 +374,7 @@ impl Runner {
             }
             Command::CreatePost(args) => {
                 let mut images = Vec::new();
-                for image in &args.images {
+                for (idx,image) in args.images.iter().enumerate() {
                     if let Ok(mut file) = File::open(image).await {
                         let mut buf = Vec::new();
                         file.read_to_end(&mut buf).await.expect("read image file");
@@ -387,13 +387,20 @@ impl Runner {
                             .upload_blob(buf)
                             .await
                             .expect("upload blob");
+                        let alt= match args.alt_text.get(idx) {
+                            Some(text) => text.to_owned(),
+                            None => {
+                                image
+                                    .file_name()
+                                    .map(|s| s.to_string_lossy().into_owned())
+                                    .unwrap_or_default()
+
+                            }
+
+                        };
                         images.push(
                             api::app::bsky::embed::images::ImageData {
-                                alt: image
-                                    .file_name()
-                                    .map(OsStr::to_string_lossy)
-                                    .unwrap_or_default()
-                                    .into(),
+                                alt,
                                 aspect_ratio: None,
                                 image: output.data.blob,
                             }


### PR DESCRIPTION
This PR adds the ability to specify alt-text on images to help give descriptive values to them.  It is written so that the alt-text input is a one-to-one map of strings based on the image filename input. 

Let me know what I need to do to help get this approved and merged!  I'm not sure what level of documentation is required since I assume `bsky-cli` is a proof-of-implementation tool, however it works just fine for me for what I need it to do so figured I'd improve it!