### PR TITLE
feat: Update XrpcClient, add AuthorizationToken

### DIFF
--- a/atrium-xrpc/src/types.rs
+++ b/atrium-xrpc/src/types.rs
@@ -1,8 +1,24 @@
-use http::header::{AUTHORIZATION, CONTENT_TYPE};
-use http::{HeaderName, Method};
+use http::header::{HeaderName, HeaderValue, InvalidHeaderValue, AUTHORIZATION, CONTENT_TYPE};
+use http::Method;
 use serde::{de::DeserializeOwned, Serialize};
 
 pub(crate) const NSID_REFRESH_SESSION: &str = "com.atproto.server.refreshSession";
+
+pub enum AuthorizationToken {
+    Bearer(String),
+    Dpop(String),
+}
+
+impl TryFrom<AuthorizationToken> for HeaderValue {
+    type Error = InvalidHeaderValue;
+
+    fn try_from(token: AuthorizationToken) -> Result<Self, Self::Error> {
+        HeaderValue::from_str(&match token {
+            AuthorizationToken::Bearer(t) => format!("Bearer {t}"),
+            AuthorizationToken::Dpop(t) => format!("DPoP {t}"),
+        })
+    }
+}
 
 /// HTTP headers which can be used in XPRC requests.
 pub enum Header {


### PR DESCRIPTION
- Rename `authentication_token` to `authorization_token`
- Add `AuthorizationToken` enum so that not only Bearer but also DPoP tokens can be used.