### PR TITLE
feat: Update oauth_client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -779,6 +780,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "pem-rfc7468",
  "pkcs8",
  "rand_core",
  "sec1",
@@ -1838,6 +1840,15 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]

--- a/atrium-oauth/oauth-client/Cargo.toml
+++ b/atrium-oauth/oauth-client/Cargo.toml
@@ -35,6 +35,7 @@ trait-variant.workspace = true
 
 [dev-dependencies]
 hickory-resolver.workspace = true
+p256 = { workspace = true, features = ["pem"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [features]

--- a/atrium-oauth/oauth-client/examples/main.rs
+++ b/atrium-oauth/oauth-client/examples/main.rs
@@ -2,8 +2,8 @@ use atrium_identity::did::{CommonDidResolver, CommonDidResolverConfig, DEFAULT_P
 use atrium_identity::handle::{AtprotoHandleResolver, AtprotoHandleResolverConfig, DnsTxtResolver};
 use atrium_oauth_client::store::state::MemoryStateStore;
 use atrium_oauth_client::{
-    AtprotoLocalhostClientMetadata, AuthorizeOptions, DefaultHttpClient, OAuthClient,
-    OAuthClientConfig, OAuthResolverConfig,
+    AtprotoLocalhostClientMetadata, AuthorizeOptions, DefaultHttpClient, KnownScope, OAuthClient,
+    OAuthClientConfig, OAuthResolverConfig, Scope,
 };
 use atrium_xrpc::http::Uri;
 use hickory_resolver::TokioAsyncResolver;
@@ -37,7 +37,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let http_client = Arc::new(DefaultHttpClient::default());
     let config = OAuthClientConfig {
         client_metadata: AtprotoLocalhostClientMetadata {
-            redirect_uris: vec!["http://127.0.0.1".to_string()],
+            redirect_uris: Some(vec![String::from("http://127.0.0.1/callback")]),
+            scopes: Some(vec![
+                Scope::Known(KnownScope::Atproto),
+                Scope::Known(KnownScope::TransitionGeneric),
+            ]),
         },
         keys: None,
         resolver: OAuthResolverConfig {
@@ -61,7 +65,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .authorize(
                 std::env::var("HANDLE").unwrap_or(String::from("https://bsky.social")),
                 AuthorizeOptions {
-                    scopes: Some(vec![String::from("atproto")]),
+                    scopes: vec![
+                        Scope::Known(KnownScope::Atproto),
+                        Scope::Known(KnownScope::TransitionGeneric)
+                    ],
                     ..Default::default()
                 }
             )

--- a/atrium-oauth/oauth-client/src/atproto.rs
+++ b/atrium-oauth/oauth-client/src/atproto.rs
@@ -160,7 +160,7 @@ impl TryIntoOAuthClientMetadata for AtprotoLocalhostClientMetadata {
             redirect_uris: self
                 .redirect_uris
                 .unwrap_or(vec![String::from("http://127.0.0.1/"), String::from("http://[::1]/")]),
-            scope: None,       // will be set to `atproto`
+            scope: None,
             grant_types: None, // will be set to `authorization_code` and `refresh_token`
             token_endpoint_auth_method: Some(String::from("none")),
             dpop_bound_access_tokens: None, // will be set to `true`

--- a/atrium-oauth/oauth-client/src/atproto.rs
+++ b/atrium-oauth/oauth-client/src/atproto.rs
@@ -1,6 +1,6 @@
 use crate::keyset::Keyset;
 use crate::types::{OAuthClientMetadata, TryIntoOAuthClientMetadata};
-use atrium_xrpc::http::Uri;
+use atrium_xrpc::http::uri::{InvalidUri, Scheme, Uri};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -18,6 +18,22 @@ pub enum Error {
     EmptyJwks,
     #[error("`private_key_jwt` auth method requires `token_endpoint_auth_signing_alg`, otherwise must not be provided")]
     AuthSigningAlg,
+    #[error(transparent)]
+    SerdeHtmlForm(#[from] serde_html_form::ser::Error),
+    #[error(transparent)]
+    LocalhostClient(#[from] LocalhostClientError),
+}
+
+#[derive(Error, Debug)]
+pub enum LocalhostClientError {
+    #[error("invalid redirect_uri: {0}")]
+    Invalid(#[from] InvalidUri),
+    #[error("loopback client_id must use `http:` redirect_uri")]
+    NotHttpScheme,
+    #[error("loopback client_id must not use `localhost` as redirect_uri hostname")]
+    Localhost,
+    #[error("loopback client_id must not use loopback addresses as redirect_uri")]
+    NotLoopbackHost,
 }
 
 pub type Result<T> = core::result::Result<T, Error>;
@@ -56,22 +72,37 @@ impl From<GrantType> for String {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(untagged)]
 pub enum Scope {
-    Atproto,
+    Known(KnownScope),
+    Unknown(String),
 }
 
-impl From<Scope> for String {
-    fn from(value: Scope) -> Self {
-        match value {
-            Scope::Atproto => String::from("atproto"),
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum KnownScope {
+    #[serde(rename = "atproto")]
+    Atproto,
+    #[serde(rename = "transition:generic")]
+    TransitionGeneric,
+    #[serde(rename = "transition:chat.bsky")]
+    TransitionChatBsky,
+}
+
+impl AsRef<str> for Scope {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::Known(KnownScope::Atproto) => "atproto",
+            Self::Known(KnownScope::TransitionGeneric) => "transition:generic",
+            Self::Known(KnownScope::TransitionChatBsky) => "transition:chat.bsky",
+            Self::Unknown(value) => value,
         }
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct AtprotoLocalhostClientMetadata {
-    pub redirect_uris: Vec<String>,
+    pub redirect_uris: Option<Vec<String>>,
+    pub scopes: Option<Vec<Scope>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -90,13 +121,45 @@ impl TryIntoOAuthClientMetadata for AtprotoLocalhostClientMetadata {
     type Error = Error;
 
     fn try_into_client_metadata(self, _: &Option<Keyset>) -> Result<OAuthClientMetadata> {
-        if self.redirect_uris.is_empty() {
-            return Err(Error::EmptyRedirectUris);
+        // validate redirect_uris
+        if let Some(redirect_uris) = &self.redirect_uris {
+            for redirect_uri in redirect_uris {
+                let uri = redirect_uri.parse::<Uri>().map_err(LocalhostClientError::Invalid)?;
+                if uri.scheme() != Some(&Scheme::HTTP) {
+                    return Err(Error::LocalhostClient(LocalhostClientError::NotHttpScheme));
+                }
+                if uri.host() == Some("localhost") {
+                    return Err(Error::LocalhostClient(LocalhostClientError::Localhost));
+                }
+                if uri.host().map_or(true, |host| host != "127.0.0.1" && host != "[::1]") {
+                    return Err(Error::LocalhostClient(LocalhostClientError::NotLoopbackHost));
+                }
+            }
+        }
+        // determine client_id
+        #[derive(serde::Serialize)]
+        struct Parameters {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            redirect_uri: Option<Vec<String>>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            scope: Option<String>,
+        }
+        let query = serde_html_form::to_string(Parameters {
+            redirect_uri: self.redirect_uris.clone(),
+            scope: self
+                .scopes
+                .map(|scopes| scopes.iter().map(AsRef::as_ref).collect::<Vec<_>>().join(" ")),
+        })?;
+        let mut client_id = String::from("http://localhost");
+        if !query.is_empty() {
+            client_id.push_str(&format!("?{query}"));
         }
         Ok(OAuthClientMetadata {
-            client_id: String::from("http://localhost"),
+            client_id,
             client_uri: None,
-            redirect_uris: self.redirect_uris,
+            redirect_uris: self
+                .redirect_uris
+                .unwrap_or(vec![String::from("http://127.0.0.1/"), String::from("http://[::1]/")]),
             scope: None,       // will be set to `atproto`
             grant_types: None, // will be set to `authorization_code` and `refresh_token`
             token_endpoint_auth_method: Some(String::from("none")),
@@ -121,7 +184,7 @@ impl TryIntoOAuthClientMetadata for AtprotoClientMetadata {
         if !self.grant_types.contains(&GrantType::AuthorizationCode) {
             return Err(Error::InvalidGrantTypes);
         }
-        if !self.scopes.contains(&Scope::Atproto) {
+        if !self.scopes.contains(&Scope::Known(KnownScope::Atproto)) {
             return Err(Error::InvalidScope);
         }
         let (jwks_uri, mut jwks) = (self.jwks_uri, None);
@@ -150,13 +213,184 @@ impl TryIntoOAuthClientMetadata for AtprotoClientMetadata {
             redirect_uris: self.redirect_uris,
             token_endpoint_auth_method: Some(self.token_endpoint_auth_method.into()),
             grant_types: Some(self.grant_types.into_iter().map(|v| v.into()).collect()),
-            scope: Some(
-                self.scopes.into_iter().map(|v| v.into()).collect::<Vec<String>>().join(" "),
-            ),
+            scope: Some(self.scopes.iter().map(AsRef::as_ref).collect::<Vec<_>>().join(" ")),
             dpop_bound_access_tokens: Some(true),
             jwks_uri,
             jwks,
             token_endpoint_auth_signing_alg: self.token_endpoint_auth_signing_alg,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use elliptic_curve::SecretKey;
+    use jose_jwk::{Jwk, Key, Parameters};
+    use p256::pkcs8::DecodePrivateKey;
+
+    const PRIVATE_KEY: &str = r#"-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgED1AAgC7Fc9kPh5T
+4i4Tn+z+tc47W1zYgzXtyjJtD92hRANCAAT80DqC+Z/JpTO7/pkPBmWqIV1IGh1P
+gbGGr0pN+oSing7cZ0169JaRHTNh+0LNQXrFobInX6cj95FzEdRyT4T3
+-----END PRIVATE KEY-----"#;
+
+    #[test]
+    fn test_localhost_client_metadata_default() {
+        let metadata = AtprotoLocalhostClientMetadata::default();
+        assert_eq!(
+            metadata.try_into_client_metadata(&None).expect("failed to convert metadata"),
+            OAuthClientMetadata {
+                client_id: String::from("http://localhost"),
+                client_uri: None,
+                redirect_uris: vec![
+                    String::from("http://127.0.0.1/"),
+                    String::from("http://[::1]/"),
+                ],
+                scope: None,
+                grant_types: None,
+                token_endpoint_auth_method: Some(AuthMethod::None.into()),
+                dpop_bound_access_tokens: None,
+                jwks_uri: None,
+                jwks: None,
+                token_endpoint_auth_signing_alg: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_localhost_client_metadata_custom() {
+        let metadata = AtprotoLocalhostClientMetadata {
+            redirect_uris: Some(vec![
+                String::from("http://127.0.0.1/callback"),
+                String::from("http://[::1]/callback"),
+            ]),
+            scopes: Some(vec![
+                Scope::Known(KnownScope::Atproto),
+                Scope::Known(KnownScope::TransitionGeneric),
+                Scope::Unknown(String::from("unknown")),
+            ]),
+        };
+        assert_eq!(
+            metadata.try_into_client_metadata(&None).expect("failed to convert metadata"),
+            OAuthClientMetadata {
+                client_id: String::from("http://localhost?redirect_uri=http%3A%2F%2F127.0.0.1%2Fcallback&redirect_uri=http%3A%2F%2F%5B%3A%3A1%5D%2Fcallback&scope=atproto+transition%3Ageneric+unknown"),
+                client_uri: None,
+                redirect_uris: vec![
+                    String::from("http://127.0.0.1/callback"),
+                    String::from("http://[::1]/callback"),
+                    ],
+                scope: None,
+                grant_types: None,
+                token_endpoint_auth_method: Some(AuthMethod::None.into()),
+                dpop_bound_access_tokens: None,
+                jwks_uri: None,
+                jwks: None,
+                token_endpoint_auth_signing_alg: None,
+            }
+        );
+    }
+
+    #[test]
+    fn test_localhost_client_metadata_invalid() {
+        {
+            let metadata = AtprotoLocalhostClientMetadata {
+                redirect_uris: Some(vec![String::from("http://")]),
+                ..Default::default()
+            };
+            let err = metadata.try_into_client_metadata(&None).expect_err("expected to fail");
+            assert!(matches!(err, Error::LocalhostClient(LocalhostClientError::Invalid(_))));
+        }
+        {
+            let metadata = AtprotoLocalhostClientMetadata {
+                redirect_uris: Some(vec![String::from("https://127.0.0.1/")]),
+                ..Default::default()
+            };
+            let err = metadata.try_into_client_metadata(&None).expect_err("expected to fail");
+            assert!(matches!(err, Error::LocalhostClient(LocalhostClientError::NotHttpScheme)));
+        }
+        {
+            let metadata = AtprotoLocalhostClientMetadata {
+                redirect_uris: Some(vec![String::from("http://localhost:8000/")]),
+                ..Default::default()
+            };
+            let err = metadata.try_into_client_metadata(&None).expect_err("expected to fail");
+            assert!(matches!(err, Error::LocalhostClient(LocalhostClientError::Localhost)));
+        }
+        {
+            let metadata = AtprotoLocalhostClientMetadata {
+                redirect_uris: Some(vec![String::from("http://192.168.0.0/")]),
+                ..Default::default()
+            };
+            let err = metadata.try_into_client_metadata(&None).expect_err("expected to fail");
+            assert!(matches!(err, Error::LocalhostClient(LocalhostClientError::NotLoopbackHost)));
+        }
+    }
+
+    #[test]
+    fn test_client_metadata() {
+        let metadata = AtprotoClientMetadata {
+            client_id: String::from("https://example.com/client_metadata.json"),
+            client_uri: String::from("https://example.com"),
+            redirect_uris: vec![String::from("https://example.com/callback")],
+            token_endpoint_auth_method: AuthMethod::PrivateKeyJwt,
+            grant_types: vec![GrantType::AuthorizationCode],
+            scopes: vec![Scope::Known(KnownScope::Atproto)],
+            jwks_uri: None,
+            token_endpoint_auth_signing_alg: Some(String::from("ES256")),
+        };
+        {
+            let metadata = metadata.clone();
+            let err = metadata.try_into_client_metadata(&None).expect_err("expected to fail");
+            assert!(matches!(err, Error::EmptyJwks));
+        }
+        {
+            let metadata = metadata.clone();
+            let secret_key = SecretKey::<p256::NistP256>::from_pkcs8_pem(PRIVATE_KEY)
+                .expect("failed to parse private key");
+            let keys = vec![Jwk {
+                key: Key::from(&secret_key.into()),
+                prm: Parameters { kid: Some(String::from("kid00")), ..Default::default() },
+            }];
+            let keyset = Keyset::try_from(keys.clone()).expect("failed to create keyset");
+            assert_eq!(
+                metadata
+                    .try_into_client_metadata(&Some(keyset.clone()))
+                    .expect("failed to convert metadata"),
+                OAuthClientMetadata {
+                    client_id: String::from("https://example.com/client_metadata.json"),
+                    client_uri: Some(String::from("https://example.com")),
+                    redirect_uris: vec![String::from("https://example.com/callback"),],
+                    scope: Some(String::from("atproto")),
+                    grant_types: Some(vec![String::from("authorization_code")]),
+                    token_endpoint_auth_method: Some(AuthMethod::PrivateKeyJwt.into()),
+                    dpop_bound_access_tokens: Some(true),
+                    jwks_uri: None,
+                    jwks: Some(keyset.public_jwks()),
+                    token_endpoint_auth_signing_alg: Some(String::from("ES256")),
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn test_scope_serde() {
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Scopes {
+            scopes: Vec<Scope>,
+        }
+
+        let scopes = Scopes {
+            scopes: vec![
+                Scope::Known(KnownScope::Atproto),
+                Scope::Known(KnownScope::TransitionGeneric),
+                Scope::Unknown(String::from("unknown")),
+            ],
+        };
+        let json = serde_json::to_string(&scopes).expect("failed to serialize scopes");
+        assert_eq!(json, r#"{"scopes":["atproto","transition:generic","unknown"]}"#);
+        let deserialized =
+            serde_json::from_str::<Scopes>(&json).expect("failed to deserialize scopes");
+        assert_eq!(deserialized, scopes);
     }
 }

--- a/atrium-oauth/oauth-client/src/http_client/dpop.rs
+++ b/atrium-oauth/oauth-client/src/http_client/dpop.rs
@@ -41,9 +41,7 @@ where
     S: SimpleStore<String, String>,
 {
     inner: Arc<T>,
-    key: Key,
-    #[allow(dead_code)]
-    iss: String,
+    pub(crate) key: Key,
     nonces: S,
     is_auth_server: bool,
 }
@@ -51,7 +49,6 @@ where
 impl<T> DpopClient<T> {
     pub fn new(
         key: Key,
-        iss: String,
         http_client: Arc<T>,
         is_auth_server: bool,
         supported_algs: &Option<Vec<String>>,
@@ -69,7 +66,7 @@ impl<T> DpopClient<T> {
             }
         }
         let nonces = MemorySimpleStore::<String, String>::default();
-        Ok(Self { inner: http_client, key, iss, nonces, is_auth_server })
+        Ok(Self { inner: http_client, key, nonces, is_auth_server })
     }
 }
 

--- a/atrium-oauth/oauth-client/src/lib.rs
+++ b/atrium-oauth/oauth-client/src/lib.rs
@@ -12,7 +12,7 @@ mod types;
 mod utils;
 
 pub use atproto::{
-    AtprotoClientMetadata, AtprotoLocalhostClientMetadata, AuthMethod, GrantType, Scope,
+    AtprotoClientMetadata, AtprotoLocalhostClientMetadata, AuthMethod, GrantType, KnownScope, Scope,
 };
 pub use error::{Error, Result};
 #[cfg(feature = "default-client")]

--- a/atrium-oauth/oauth-client/src/oauth_client.rs
+++ b/atrium-oauth/oauth-client/src/oauth_client.rs
@@ -165,7 +165,7 @@ where
             response_type: AuthorizationResponseType::Code,
             redirect_uri,
             state,
-            scope: options.scopes.map(|v| v.join(" ")),
+            scope: Some(options.scopes.iter().map(AsRef::as_ref).collect::<Vec<_>>().join(" ")),
             response_mode: None,
             code_challenge,
             code_challenge_method: AuthorizationCodeChallengeMethod::S256,
@@ -255,8 +255,6 @@ where
         // https://datatracker.ietf.org/doc/html/rfc7636#section-4.1
         let verifier =
             URL_SAFE_NO_PAD.encode(get_random_values::<_, 32>(&mut ThreadRng::default()));
-        let mut hasher = Sha256::new();
-        hasher.update(verifier.as_bytes());
-        (URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes())), verifier)
+        (URL_SAFE_NO_PAD.encode(Sha256::digest(&verifier)), verifier)
     }
 }

--- a/atrium-oauth/oauth-client/src/server_agent.rs
+++ b/atrium-oauth/oauth-client/src/server_agent.rs
@@ -122,6 +122,7 @@ where
             dpop_key,
             client_metadata.client_id.clone(),
             http_client,
+            true,
             &server_metadata.token_endpoint_auth_signing_alg_values_supported,
         )?;
         Ok(Self { server_metadata, client_metadata, dpop_client, resolver, keyset })

--- a/atrium-oauth/oauth-client/src/types.rs
+++ b/atrium-oauth/oauth-client/src/types.rs
@@ -9,7 +9,8 @@ pub use client_metadata::{OAuthClientMetadata, TryIntoOAuthClientMetadata};
 pub use metadata::{OAuthAuthorizationServerMetadata, OAuthProtectedResourceMetadata};
 pub use request::{
     AuthorizationCodeChallengeMethod, AuthorizationResponseType,
-    PushedAuthorizationRequestParameters, TokenGrantType, TokenRequestParameters,
+    PushedAuthorizationRequestParameters, RefreshRequestParameters, TokenGrantType,
+    TokenRequestParameters,
 };
 pub use response::{OAuthPusehedAuthorizationRequestResponse, OAuthTokenResponse};
 use serde::Deserialize;

--- a/atrium-oauth/oauth-client/src/types.rs
+++ b/atrium-oauth/oauth-client/src/types.rs
@@ -4,6 +4,7 @@ mod request;
 mod response;
 mod token;
 
+use crate::atproto::{KnownScope, Scope};
 pub use client_metadata::{OAuthClientMetadata, TryIntoOAuthClientMetadata};
 pub use metadata::{OAuthAuthorizationServerMetadata, OAuthProtectedResourceMetadata};
 pub use request::{
@@ -36,13 +37,19 @@ impl From<AuthorizeOptionPrompt> for String {
 #[derive(Debug, Deserialize)]
 pub struct AuthorizeOptions {
     pub redirect_uri: Option<String>,
-    pub scopes: Option<Vec<String>>, // TODO: enum?
+    pub scopes: Vec<Scope>,
     pub prompt: Option<AuthorizeOptionPrompt>,
+    pub state: Option<String>,
 }
 
 impl Default for AuthorizeOptions {
     fn default() -> Self {
-        Self { redirect_uri: None, scopes: Some(vec![String::from("atproto")]), prompt: None }
+        Self {
+            redirect_uri: None,
+            scopes: vec![Scope::Known(KnownScope::Atproto)],
+            prompt: None,
+            state: None,
+        }
     }
 }
 

--- a/atrium-oauth/oauth-client/src/types/request.rs
+++ b/atrium-oauth/oauth-client/src/types/request.rs
@@ -49,6 +49,8 @@ pub struct PushedAuthorizationRequestParameters {
 #[serde(rename_all = "snake_case")]
 pub enum TokenGrantType {
     AuthorizationCode,
+    #[allow(dead_code)]
+    RefreshToken,
 }
 
 #[derive(Serialize)]
@@ -59,4 +61,12 @@ pub struct TokenRequestParameters {
     pub redirect_uri: String,
     // https://datatracker.ietf.org/doc/html/rfc7636#section-4.5
     pub code_verifier: String,
+}
+
+#[derive(Serialize)]
+pub struct RefreshRequestParameters {
+    // https://datatracker.ietf.org/doc/html/rfc6749#section-6
+    pub grant_type: TokenGrantType,
+    pub refresh_token: String,
+    pub scope: Option<String>,
 }


### PR DESCRIPTION
- Update `atproto::AtprotoLocalhostClientMetadata`
  - Make `redirect_uri` and `scope` configurable
  - Add tests
- Update `DpopClient`
  - Include `ath` in the proof when access_token is set in the `Authorization` header of the request
  - Improved judgment process of `is_use_dpop_nonce_error` method
  - Remove unused fields
- Add request parameters for refresh token