### PR TITLE
Fix firehose example

### DIFF
--- a/examples/firehose/Cargo.toml
+++ b/examples/firehose/Cargo.toml
@@ -7,12 +7,17 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.80"
-atrium-api = { version = "0.18.1", features = ["dag-cbor"] }
+# atrium-api = { version = "0.18.1", features = ["dag-cbor"] }
+atrium-api = { path = "../../atrium-api" }
 chrono = "0.4.34"
+cid_old = { package = "cid", version = "0.10.1" }
+cid = { package = "cid", version = "0.11.1" }
 futures = "0.3.30"
 ipld-core = { version = "0.4.0", default-features = false, features = ["std"] }
 rs-car = "0.4.1"
-serde_ipld_dagcbor = { version = "0.6.0", default-features = false, features = ["std"] }
+serde_ipld_dagcbor = { version = "0.6.0", default-features = false, features = [
+    "std",
+] }
 tokio = { version = "1.36.0", features = ["full"] }
 tokio-tungstenite = { version = "0.21.0", features = ["native-tls"] }
 trait-variant = "0.1.1"

--- a/examples/firehose/Cargo.toml
+++ b/examples/firehose/Cargo.toml
@@ -7,8 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.80"
-# atrium-api = { version = "0.18.1", features = ["dag-cbor"] }
-atrium-api = { path = "../../atrium-api" }
+atrium-api = { version = "0.24.8" }
 chrono = "0.4.34"
 cid_old = { package = "cid", version = "0.10.1" }
 cid = { package = "cid", version = "0.11.1" }

--- a/examples/firehose/src/cid_compat.rs
+++ b/examples/firehose/src/cid_compat.rs
@@ -1,0 +1,24 @@
+use cid::{multihash::Multihash, Cid};
+
+pub struct CidOld(cid_old::Cid);
+
+impl From<cid_old::Cid> for CidOld {
+    fn from(value: cid_old::Cid) -> Self {
+        Self(value)
+    }
+}
+impl TryFrom<CidOld> for Cid {
+    type Error = cid::Error;
+    fn try_from(value: CidOld) -> Result<Self, Self::Error> {
+        let version = match value.0.version() {
+            cid_old::Version::V0 => cid::Version::V0,
+            cid_old::Version::V1 => cid::Version::V1,
+        };
+
+        let codec = value.0.codec();
+        let hash = value.0.hash();
+        let hash = Multihash::from_bytes(&hash.to_bytes())?;
+
+        Self::new(version, codec, hash)
+    }
+}

--- a/examples/firehose/src/lib.rs
+++ b/examples/firehose/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod cid_compat;
 pub mod stream;
 pub mod subscription;


### PR DESCRIPTION
the `firehose` example currently transitively has dependencies on two versions of `cid`: `v0.10.1` and `v0.11.1`, which have different types for `Cid`. 

This PR doesn't fix the root issue (haven't had the time to drill down), but adds a newtype + a dependency on the example to convert from the old cid to the new cid. 
It's merely a band-aid but I think it's important to keep examples working, as it is a great way of getting started. 

Thanks a lot for the library btw :)