### PR TITLE
feat: Add `Tid::now` and `Tid::from_datetime` constructors

### DIFF
--- a/atrium-api/src/types/string.rs
+++ b/atrium-api/src/types/string.rs
@@ -456,8 +456,10 @@ impl Tid {
 
     /// Construct a new timestamp with the specified clock ID.
     ///
-    /// Clock IDs 0-31 can be used as an ad-hoc clock ID if you are not concerned
-    /// with this parameter.
+    /// If you have multiple clock sources, you can use `clkid` to distinguish between them
+    /// and hint to other implementations that the timestamp cannot be compared with other
+    /// timestamps from other sources.
+    /// If you are only using a single clock source, you can just specify `0` for `clkid`.
     pub fn from_datetime(clkid: LimitedU32<1023>, time: chrono::DateTime<chrono::Utc>) -> Self {
         let time = time.timestamp_micros() as u64;
 
@@ -469,8 +471,10 @@ impl Tid {
 
     /// Construct a new [Tid] that represents the current time.
     ///
-    /// Clock IDs 0-31 can be used as an ad-hoc clock ID if you are not concerned
-    /// with this parameter.
+    /// If you have multiple clock sources, you can use `clkid` to distinguish between them
+    /// and hint to other implementations that the timestamp cannot be compared with other
+    /// timestamps from other sources.
+    /// If you are only using a single clock source, you can just specify `0` for `clkid`.
     pub fn now(clkid: LimitedU32<1023>) -> Self {
         Self::from_datetime(clkid, chrono::Utc::now())
     }

--- a/atrium-api/src/types/string.rs
+++ b/atrium-api/src/types/string.rs
@@ -456,13 +456,21 @@ impl Tid {
     ///
     /// Clock IDs 0-31 can be used as an ad-hoc clock ID if you are not concerned
     /// with this parameter.
-    pub fn now(cid: u32) -> Self {
-        let now = chrono::Utc::now().timestamp_micros() as u64;
+    pub fn from_datetime(cid: u32, time: chrono::DateTime<chrono::Utc>) -> Self {
+        let time = time.timestamp_micros() as u64;
 
         // The TID is laid out as follows:
         // 0TTTTTTTTTTTTTTT TTTTTTTTTTTTTTTT TTTTTTTTTTTTTTTT TTTTTTCCCCCCCCCC
-        let tid = (now << 10) & 0x7FFF_FFFF_FFFF_FC00 | (cid as u64) & 0x3FF;
+        let tid = (time << 10) & 0x7FFF_FFFF_FFFF_FC00 | (cid as u64) & 0x3FF;
         Self(s32_encode(tid))
+    }
+
+    /// Construct a new [Tid] that represents the current time.
+    ///
+    /// Clock IDs 0-31 can be used as an ad-hoc clock ID if you are not concerned
+    /// with this parameter.
+    pub fn now(cid: u32) -> Self {
+        Self::from_datetime(cid, chrono::Utc::now())
     }
 
     /// Returns the TID as a string slice.
@@ -799,6 +807,12 @@ mod tests {
     fn tid_encode() {
         assert_eq!(s32_encode(0), "2222222222222");
         assert_eq!(s32_encode(1), "2222222222223");
+    }
+
+    #[test]
+    fn tid_construct() {
+        let tid = Tid::from_datetime(0, chrono::DateTime::from_timestamp(1738430999, 0).unwrap());
+        assert_eq!(tid.as_str(), "3lh5234mwy222");
     }
 
     #[test]

--- a/atrium-api/src/types/string.rs
+++ b/atrium-api/src/types/string.rs
@@ -475,6 +475,10 @@ impl Tid {
     /// and hint to other implementations that the timestamp cannot be compared with other
     /// timestamps from other sources.
     /// If you are only using a single clock source, you can just specify `0` for `clkid`.
+    ///
+    /// _Warning:_ It's possible that this function will return the same time more than once.
+    /// If it's important that these values be unique, you will want to repeatedly call this
+    /// function until a different time is returned.
     pub fn now(clkid: LimitedU32<1023>) -> Self {
         Self::from_datetime(clkid, chrono::Utc::now())
     }


### PR DESCRIPTION
This simply adds some new `Tid` convenience constructors so that users do not have to write their own if they want to construct a timestamp.