### PR TITLE
feat: Agent rework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 name = "atrium-api"
 version = "0.24.10"
 dependencies = [
+ "atrium-common",
  "atrium-xrpc",
  "atrium-xrpc-client",
  "bumpalo",
@@ -388,6 +389,7 @@ version = "0.1.15"
 dependencies = [
  "anyhow",
  "atrium-api",
+ "atrium-common",
  "atrium-xrpc-client",
  "chrono",
  "ipld-core",
@@ -1659,9 +1661,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -2828,9 +2830,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2846,9 +2848,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ hickory-resolver = "0.24.1"
 http = "1.1.0"
 lru = "0.12.4"
 moka = "0.12.8"
-tokio = { version = "1.39", default-features = false }
+tokio = { version = "1.43", default-features = false }
 
 # HTTP client integrations
 isahc = "1.7.2"

--- a/atrium-api/Cargo.toml
+++ b/atrium-api/Cargo.toml
@@ -12,6 +12,7 @@ license.workspace = true
 keywords.workspace = true
 
 [dependencies]
+atrium-common.workspace = true
 atrium-xrpc.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 http.workspace = true

--- a/atrium-api/README.md
+++ b/atrium-api/README.md
@@ -44,7 +44,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 While `AtpServiceClient` can be used for simple XRPC calls, it is better to use `AtpAgent`, which has practical features such as session management.
 
 ```rust,no_run
-use atrium_api::agent::{store::MemorySessionStore, AtpAgent};
+use atrium_api::agent::atp_agent::{store::MemorySessionStore, AtpAgent};
 use atrium_xrpc_client::reqwest::ReqwestClient;
 
 #[tokio::main]

--- a/atrium-api/src/agent.rs
+++ b/atrium-api/src/agent.rs
@@ -1,3 +1,5 @@
+//! Structs and traits for managing sessions and making the XRPC requests.
+
 pub mod atp_agent;
 #[cfg(feature = "bluesky")]
 pub mod bluesky;
@@ -10,6 +12,7 @@ use crate::{client::Service, types::string::Did};
 use atrium_xrpc::types::AuthorizationToken;
 use std::{future::Future, sync::Arc};
 
+/// A trait for providing authorization tokens.
 #[cfg_attr(not(target_arch = "wasm32"), trait_variant::make(Send))]
 pub trait AuthorizationProvider {
     #[allow(unused_variables)]
@@ -19,6 +22,7 @@ pub trait AuthorizationProvider {
     ) -> impl Future<Output = Option<AuthorizationToken>>;
 }
 
+/// A trait for configuring the endpoint and headers of a client.
 pub trait Configure {
     /// Set the current endpoint.
     fn configure_endpoint(&self, endpoint: String);
@@ -28,6 +32,7 @@ pub trait Configure {
     fn configure_proxy_header(&self, did: Did, service_type: impl AsRef<str>);
 }
 
+/// A trait for cloning a client with a proxy header.
 pub trait CloneWithProxy {
     fn clone_with_proxy(&self, did: Did, service_type: impl AsRef<str>) -> Self;
 }

--- a/atrium-api/src/agent.rs
+++ b/atrium-api/src/agent.rs
@@ -55,6 +55,26 @@ impl AsRef<str> for AtprotoServiceType {
     }
 }
 
+/// A wrapper around a session manager and a client service.
+///
+/// An agent provides the following utilities:
+/// - AT Protocol labelers configuration utilities
+/// - AT Protocol proxy configuration utilities
+/// - Cloning utilities (if the session manager implements [`CloneWithProxy`])
+///
+/// # Example
+///
+/// ```
+/// use atrium_api::agent::atp_agent::{store::MemorySessionStore, CredentialSession};
+/// use atrium_api::agent::Agent;
+/// use atrium_xrpc_client::reqwest::ReqwestClient;
+///
+/// let session = CredentialSession::new(
+///     ReqwestClient::new("https://bsky.social"),
+///     MemorySessionStore::default(),
+/// );
+/// let agent = Agent::new(session);
+/// ``````
 pub struct Agent<M>
 where
     M: SessionManager + Send + Sync,
@@ -67,11 +87,13 @@ impl<M> Agent<M>
 where
     M: SessionManager + Send + Sync,
 {
+    /// Creates a new agent with the given session manager.
     pub fn new(session_manager: M) -> Self {
         let session_manager = Arc::new(inner::Wrapper::new(session_manager));
         let api = Service::new(session_manager.clone());
         Self { session_manager, api }
     }
+    /// Returns the DID of the current session.
     pub async fn did(&self) -> Option<Did> {
         self.session_manager.did().await
     }

--- a/atrium-api/src/agent/atp_agent.rs
+++ b/atrium-api/src/agent/atp_agent.rs
@@ -1,4 +1,4 @@
-//! Implementation of [`AtpAgent`] and definitions of [`SessionStore`] for it.
+//! Implementation of [`AtpAgent`] and definitions of [`AtpSessionStore`] for it.
 
 mod inner;
 pub mod store;

--- a/atrium-api/src/agent/atp_agent.rs
+++ b/atrium-api/src/agent/atp_agent.rs
@@ -207,6 +207,9 @@ where
 ///
 /// This will be deprecated in the near future. Use [`Agent`] directly
 /// with a [`CredentialSession`] instead:
+///
+/// # Example
+///
 /// ```
 /// use atrium_api::agent::atp_agent::{store::MemorySessionStore, CredentialSession};
 /// use atrium_api::agent::Agent;

--- a/atrium-api/src/agent/atp_agent.rs
+++ b/atrium-api/src/agent/atp_agent.rs
@@ -1,0 +1,949 @@
+//! Implementation of [`AtpAgent`] and definitions of [`SessionStore`] for it.
+
+mod inner;
+pub mod store;
+
+use self::store::AtpSessionStore;
+use super::{
+    inner::Wrapper, utils::SessionWithEndpointStore, Agent, CloneWithProxy, Configure,
+    SessionManager,
+};
+use crate::{
+    client::com::atproto::Service,
+    did_doc::DidDocument,
+    types::{string::Did, TryFromUnknown},
+};
+use atrium_xrpc::{Error, HttpClient, OutputDataOrBytes, XrpcClient, XrpcRequest};
+use http::{Request, Response};
+use serde::{de::DeserializeOwned, Serialize};
+use std::{convert, fmt::Debug, ops::Deref, sync::Arc};
+
+/// Type alias for the [com::atproto::server::create_session::Output](crate::com::atproto::server::create_session::Output)
+pub type AtpSession = crate::com::atproto::server::create_session::Output;
+
+pub struct CredentialSession<S, T>
+where
+    S: AtpSessionStore + Send + Sync,
+    T: XrpcClient + Send + Sync,
+    S::Error: std::error::Error + Send + Sync + 'static,
+{
+    store: Arc<SessionWithEndpointStore<S, AtpSession>>,
+    inner: Arc<inner::Client<S, T>>,
+    atproto_service: Service<inner::Client<S, T>>,
+}
+
+impl<S, T> CredentialSession<S, T>
+where
+    S: AtpSessionStore + Send + Sync,
+    T: XrpcClient + Send + Sync,
+    S::Error: std::error::Error + Send + Sync + 'static,
+{
+    pub fn new(xrpc: T, store: S) -> Self {
+        let store = Arc::new(SessionWithEndpointStore::new(store, xrpc.base_uri()));
+        let inner = Arc::new(inner::Client::new(Arc::clone(&store), xrpc));
+        let atproto_service = Service::new(Arc::clone(&inner));
+        Self { store, inner, atproto_service }
+    }
+    /// Start a new session with this agent.
+    pub async fn login(
+        &self,
+        identifier: impl AsRef<str>,
+        password: impl AsRef<str>,
+    ) -> Result<AtpSession, Error<crate::com::atproto::server::create_session::Error>> {
+        let result = self
+            .atproto_service
+            .server
+            .create_session(
+                crate::com::atproto::server::create_session::InputData {
+                    allow_takendown: None,
+                    auth_factor_token: None,
+                    identifier: identifier.as_ref().into(),
+                    password: password.as_ref().into(),
+                }
+                .into(),
+            )
+            .await?;
+        self.store.set(result.clone()).await.ok();
+        if let Some(did_doc) = result
+            .did_doc
+            .as_ref()
+            .and_then(|value| DidDocument::try_from_unknown(value.clone()).ok())
+        {
+            self.store.update_endpoint(&did_doc);
+        }
+        Ok(result)
+    }
+    /// Resume a pre-existing session with this agent.
+    pub async fn resume_session(
+        &self,
+        session: AtpSession,
+    ) -> Result<(), Error<crate::com::atproto::server::get_session::Error>> {
+        self.store.set(session.clone()).await.ok();
+        let result = self.atproto_service.server.get_session().await;
+        match result {
+            Ok(output) => {
+                assert_eq!(output.data.did, session.data.did);
+                if let Ok(Some(mut session)) = self.store.get().await {
+                    session.did_doc = output.data.did_doc.clone();
+                    session.email = output.data.email;
+                    session.email_confirmed = output.data.email_confirmed;
+                    session.handle = output.data.handle;
+                    self.store.set(session).await.ok();
+                }
+                if let Some(did_doc) = output
+                    .data
+                    .did_doc
+                    .as_ref()
+                    .and_then(|value| DidDocument::try_from_unknown(value.clone()).ok())
+                {
+                    self.store.update_endpoint(&did_doc);
+                }
+                Ok(())
+            }
+            Err(err) => {
+                self.store.clear().await.ok();
+                Err(err)
+            }
+        }
+    }
+    /// Get the current session.
+    pub async fn get_session(&self) -> Option<AtpSession> {
+        self.store.get().await.ok().and_then(convert::identity)
+    }
+    /// Get the current endpoint.
+    pub async fn get_endpoint(&self) -> String {
+        self.store.get_endpoint()
+    }
+    /// Get the current labelers header.
+    pub async fn get_labelers_header(&self) -> Option<Vec<String>> {
+        self.inner.get_labelers_header().await
+    }
+    /// Get the current proxy header.
+    pub async fn get_proxy_header(&self) -> Option<String> {
+        self.inner.get_proxy_header().await
+    }
+}
+
+impl<S, T> HttpClient for CredentialSession<S, T>
+where
+    S: AtpSessionStore + Send + Sync,
+    T: XrpcClient + Send + Sync,
+    S::Error: std::error::Error + Send + Sync + 'static,
+{
+    async fn send_http(
+        &self,
+        request: Request<Vec<u8>>,
+    ) -> Result<Response<Vec<u8>>, Box<dyn std::error::Error + Send + Sync + 'static>> {
+        self.inner.send_http(request).await
+    }
+}
+
+impl<S, T> XrpcClient for CredentialSession<S, T>
+where
+    S: AtpSessionStore + Send + Sync,
+    T: XrpcClient + Send + Sync,
+    S::Error: std::error::Error + Send + Sync + 'static,
+{
+    fn base_uri(&self) -> String {
+        self.inner.base_uri()
+    }
+    async fn send_xrpc<P, I, O, E>(
+        &self,
+        request: &XrpcRequest<P, I>,
+    ) -> Result<OutputDataOrBytes<O>, Error<E>>
+    where
+        P: Serialize + Send + Sync,
+        I: Serialize + Send + Sync,
+        O: DeserializeOwned + Send + Sync,
+        E: DeserializeOwned + Send + Sync + Debug,
+    {
+        self.inner.send_xrpc(request).await
+    }
+}
+
+impl<S, T> SessionManager for CredentialSession<S, T>
+where
+    S: AtpSessionStore + Send + Sync,
+    T: XrpcClient + Send + Sync,
+    S::Error: std::error::Error + Send + Sync + 'static,
+{
+    async fn did(&self) -> Option<Did> {
+        self.store.get().await.ok().and_then(|session| session.map(|session| session.data.did))
+    }
+}
+
+impl<S, T> Configure for CredentialSession<S, T>
+where
+    S: AtpSessionStore + Send + Sync,
+    T: XrpcClient + Send + Sync,
+    S::Error: std::error::Error + Send + Sync + 'static,
+{
+    fn configure_endpoint(&self, endpoint: String) {
+        self.inner.configure_endpoint(endpoint);
+    }
+    fn configure_labelers_header(&self, labeler_dids: Option<Vec<(Did, bool)>>) {
+        self.inner.configure_labelers_header(labeler_dids);
+    }
+    fn configure_proxy_header(&self, did: Did, service_type: impl AsRef<str>) {
+        self.inner.configure_proxy_header(did, service_type);
+    }
+}
+
+impl<S, T> CloneWithProxy for CredentialSession<S, T>
+where
+    S: AtpSessionStore + Send + Sync,
+    S::Error: std::error::Error + Send + Sync + 'static,
+    T: XrpcClient + Send + Sync,
+{
+    fn clone_with_proxy(&self, did: Did, service_type: impl AsRef<str>) -> Self {
+        let inner = Arc::new(self.inner.clone_with_proxy(did, service_type));
+        let atproto_service = Service::new(Arc::clone(&inner));
+        Self { store: Arc::clone(&self.store), inner, atproto_service }
+    }
+}
+
+/// An ATP "Agent".
+/// Manages session token lifecycles and provides convenience methods.
+///
+/// This will be deprecated in the near future. Use [`Agent`] directly
+/// with a [`CredentialSession`] instead:
+/// ```
+/// use atrium_api::agent::atp_agent::{store::MemorySessionStore, CredentialSession};
+/// use atrium_api::agent::Agent;
+/// use atrium_xrpc_client::reqwest::ReqwestClient;
+///
+/// let session = CredentialSession::new(
+///     ReqwestClient::new("https://bsky.social"),
+///     MemorySessionStore::default(),
+/// );
+/// let agent = Agent::new(session);
+/// ```
+pub struct AtpAgent<S, T>
+where
+    S: AtpSessionStore + Send + Sync,
+    T: XrpcClient + Send + Sync,
+    S::Error: std::error::Error + Send + Sync + 'static,
+{
+    session_manager: Wrapper<CredentialSession<S, T>>,
+    inner: Agent<Wrapper<CredentialSession<S, T>>>,
+}
+
+impl<S, T> AtpAgent<S, T>
+where
+    S: AtpSessionStore + Send + Sync,
+    T: XrpcClient + Send + Sync,
+    S::Error: std::error::Error + Send + Sync + 'static,
+{
+    /// Create a new agent.
+    pub fn new(xrpc: T, store: S) -> Self {
+        let session_manager = Wrapper::new(CredentialSession::new(xrpc, store));
+        let inner = Agent::new(session_manager.clone());
+        Self { session_manager, inner }
+    }
+    /// Start a new session with this agent.
+    pub async fn login(
+        &self,
+        identifier: impl AsRef<str>,
+        password: impl AsRef<str>,
+    ) -> Result<AtpSession, Error<crate::com::atproto::server::create_session::Error>> {
+        self.session_manager.login(identifier, password).await
+    }
+    // /// Resume a pre-existing session with this agent.
+    pub async fn resume_session(
+        &self,
+        session: AtpSession,
+    ) -> Result<(), Error<crate::com::atproto::server::get_session::Error>> {
+        self.session_manager.resume_session(session).await
+    }
+    /// Get the current session.
+    pub async fn get_session(&self) -> Option<AtpSession> {
+        self.session_manager.get_session().await
+    }
+    /// Get the current endpoint.
+    pub async fn get_endpoint(&self) -> String {
+        self.session_manager.get_endpoint().await
+    }
+    /// Get the current labelers header.
+    pub async fn get_labelers_header(&self) -> Option<Vec<String>> {
+        self.session_manager.get_labelers_header().await
+    }
+    /// Get the current proxy header.
+    pub async fn get_proxy_header(&self) -> Option<String> {
+        self.session_manager.get_proxy_header().await
+    }
+}
+
+impl<S, T> Deref for AtpAgent<S, T>
+where
+    S: AtpSessionStore + Send + Sync,
+    T: XrpcClient + Send + Sync,
+    S::Error: std::error::Error + Send + Sync + 'static,
+{
+    type Target = Agent<Wrapper<CredentialSession<S, T>>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::store::MemorySessionStore;
+    use super::*;
+    use crate::{
+        agent::AtprotoServiceType,
+        com::atproto::server::create_session::OutputData,
+        did_doc::{DidDocument, Service, VerificationMethod},
+        types::TryIntoUnknown,
+    };
+    use atrium_xrpc::HttpClient;
+    use http::{HeaderMap, HeaderName, HeaderValue, Request, Response};
+    use std::collections::HashMap;
+    use tokio::sync::RwLock;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    #[derive(Default)]
+    struct MockResponses {
+        create_session: Option<crate::com::atproto::server::create_session::OutputData>,
+        get_session: Option<crate::com::atproto::server::get_session::OutputData>,
+    }
+
+    #[derive(Default)]
+    struct MockClient {
+        responses: MockResponses,
+        counts: Arc<RwLock<HashMap<String, usize>>>,
+        headers: Arc<RwLock<Vec<HeaderMap<HeaderValue>>>>,
+    }
+
+    impl HttpClient for MockClient {
+        async fn send_http(
+            &self,
+            request: Request<Vec<u8>>,
+        ) -> Result<Response<Vec<u8>>, Box<dyn std::error::Error + Send + Sync + 'static>> {
+            #[cfg(not(target_arch = "wasm32"))]
+            tokio::time::sleep(std::time::Duration::from_micros(10)).await;
+
+            self.headers.write().await.push(request.headers().clone());
+            let builder =
+                Response::builder().header(http::header::CONTENT_TYPE, "application/json");
+            let token = request
+                .headers()
+                .get(http::header::AUTHORIZATION)
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.split(' ').last());
+            if token == Some("expired") {
+                return Ok(builder.status(http::StatusCode::BAD_REQUEST).body(
+                    serde_json::to_vec(&atrium_xrpc::error::ErrorResponseBody {
+                        error: Some(String::from("ExpiredToken")),
+                        message: Some(String::from("Token has expired")),
+                    })?,
+                )?);
+            }
+            let mut body = Vec::new();
+            if let Some(nsid) = request.uri().path().strip_prefix("/xrpc/") {
+                *self.counts.write().await.entry(nsid.into()).or_default() += 1;
+                match nsid {
+                    crate::com::atproto::server::create_session::NSID => {
+                        if let Some(output) = &self.responses.create_session {
+                            body.extend(serde_json::to_vec(output)?);
+                        }
+                    }
+                    crate::com::atproto::server::get_session::NSID => {
+                        if token == Some("access") {
+                            if let Some(output) = &self.responses.get_session {
+                                body.extend(serde_json::to_vec(output)?);
+                            }
+                        }
+                    }
+                    crate::com::atproto::server::refresh_session::NSID => {
+                        if token == Some("refresh") {
+                            body.extend(serde_json::to_vec(
+                                &crate::com::atproto::server::refresh_session::OutputData {
+                                    access_jwt: String::from("access"),
+                                    active: None,
+                                    did: "did:web:example.com".parse().expect("valid"),
+                                    did_doc: None,
+                                    handle: "example.com".parse().expect("valid"),
+                                    refresh_jwt: String::from("refresh"),
+                                    status: None,
+                                },
+                            )?);
+                        }
+                    }
+                    crate::com::atproto::server::describe_server::NSID => {
+                        body.extend(serde_json::to_vec(
+                            &crate::com::atproto::server::describe_server::OutputData {
+                                available_user_domains: Vec::new(),
+                                contact: None,
+                                did: "did:web:example.com".parse().expect("valid"),
+                                invite_code_required: None,
+                                links: None,
+                                phone_verification_required: None,
+                            },
+                        )?);
+                    }
+                    _ => {}
+                }
+            }
+            if body.is_empty() {
+                Ok(builder.status(http::StatusCode::UNAUTHORIZED).body(serde_json::to_vec(
+                    &atrium_xrpc::error::ErrorResponseBody {
+                        error: Some(String::from("AuthenticationRequired")),
+                        message: Some(String::from("Invalid identifier or password")),
+                    },
+                )?)?)
+            } else {
+                Ok(builder.status(http::StatusCode::OK).body(body)?)
+            }
+        }
+    }
+
+    impl XrpcClient for MockClient {
+        fn base_uri(&self) -> String {
+            "http://localhost:8080".into()
+        }
+    }
+
+    fn session_data() -> OutputData {
+        OutputData {
+            access_jwt: String::from("access"),
+            active: None,
+            did: "did:web:example.com".parse().expect("valid"),
+            did_doc: None,
+            email: None,
+            email_auth_factor: None,
+            email_confirmed: None,
+            handle: "example.com".parse().expect("valid"),
+            refresh_jwt: String::from("refresh"),
+            status: None,
+        }
+    }
+
+    #[tokio::test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    async fn test_new() {
+        let agent = AtpAgent::new(MockClient::default(), MemorySessionStore::default());
+        assert_eq!(agent.get_session().await, None);
+    }
+
+    #[tokio::test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    async fn test_login() {
+        let session_data = session_data();
+        // success
+        {
+            let client = MockClient {
+                responses: MockResponses {
+                    create_session: Some(crate::com::atproto::server::create_session::OutputData {
+                        ..session_data.clone()
+                    }),
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let agent = AtpAgent::new(client, MemorySessionStore::default());
+            agent.login("test", "pass").await.expect("login should be succeeded");
+            assert_eq!(agent.get_session().await, Some(session_data.into()));
+        }
+        // failure with `createSession` error
+        {
+            let client = MockClient {
+                responses: MockResponses { ..Default::default() },
+                ..Default::default()
+            };
+            let agent = AtpAgent::new(client, MemorySessionStore::default());
+            agent.login("test", "bad").await.expect_err("login should be failed");
+            assert_eq!(agent.get_session().await, None);
+        }
+    }
+
+    #[tokio::test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    async fn test_xrpc_get_session() {
+        let session_data = session_data();
+        let client = MockClient {
+            responses: MockResponses {
+                get_session: Some(crate::com::atproto::server::get_session::OutputData {
+                    active: session_data.active,
+                    did: session_data.did.clone(),
+                    did_doc: session_data.did_doc.clone(),
+                    email: session_data.email.clone(),
+                    email_auth_factor: session_data.email_auth_factor,
+                    email_confirmed: session_data.email_confirmed,
+                    handle: session_data.handle.clone(),
+                    status: session_data.status.clone(),
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let agent = AtpAgent::new(client, MemorySessionStore::default());
+        agent
+            .session_manager
+            .store
+            .set(session_data.clone().into())
+            .await
+            .expect("set session should be succeeded");
+        let output = agent
+            .api
+            .com
+            .atproto
+            .server
+            .get_session()
+            .await
+            .expect("get session should be succeeded");
+        assert_eq!(output.did.as_str(), "did:web:example.com");
+    }
+
+    #[tokio::test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    async fn test_xrpc_get_session_with_refresh() {
+        let mut session_data = session_data();
+        session_data.access_jwt = String::from("expired");
+        let client = MockClient {
+            responses: MockResponses {
+                get_session: Some(crate::com::atproto::server::get_session::OutputData {
+                    active: session_data.active,
+                    did: session_data.did.clone(),
+                    did_doc: session_data.did_doc.clone(),
+                    email: session_data.email.clone(),
+                    email_auth_factor: session_data.email_auth_factor,
+                    email_confirmed: session_data.email_confirmed,
+                    handle: session_data.handle.clone(),
+                    status: session_data.status.clone(),
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let agent = AtpAgent::new(client, MemorySessionStore::default());
+        agent
+            .session_manager
+            .store
+            .set(session_data.clone().into())
+            .await
+            .expect("set session should be succeeded");
+        let output = agent
+            .api
+            .com
+            .atproto
+            .server
+            .get_session()
+            .await
+            .expect("get session should be succeeded");
+        assert_eq!(output.did.as_str(), "did:web:example.com");
+        assert_eq!(
+            agent
+                .session_manager
+                .store
+                .get()
+                .await
+                .expect("session should be stored")
+                .map(|session| session.data.access_jwt),
+            Some("access".into())
+        );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn test_xrpc_get_session_with_duplicated_refresh() {
+        let mut session_data = session_data();
+        session_data.access_jwt = String::from("expired");
+        let client = MockClient {
+            responses: MockResponses {
+                get_session: Some(crate::com::atproto::server::get_session::OutputData {
+                    active: session_data.active,
+                    did: session_data.did.clone(),
+                    did_doc: session_data.did_doc.clone(),
+                    email: session_data.email.clone(),
+                    email_auth_factor: session_data.email_auth_factor,
+                    email_confirmed: session_data.email_confirmed,
+                    handle: session_data.handle.clone(),
+                    status: session_data.status.clone(),
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let counts = Arc::clone(&client.counts);
+        let agent = Arc::new(AtpAgent::new(client, MemorySessionStore::default()));
+        agent
+            .session_manager
+            .store
+            .set(session_data.clone().into())
+            .await
+            .expect("set session should be succeeded");
+        let handles = (0..3).map(|_| {
+            let agent = Arc::clone(&agent);
+            tokio::spawn(async move { agent.api.com.atproto.server.get_session().await })
+        });
+        let results = futures::future::join_all(handles).await;
+        for result in &results {
+            let output = result
+                .as_ref()
+                .expect("task should be successfully executed")
+                .as_ref()
+                .expect("get session should be succeeded");
+            assert_eq!(output.did.as_str(), "did:web:example.com");
+        }
+        assert_eq!(
+            agent
+                .session_manager
+                .store
+                .get()
+                .await
+                .expect("session should be stored")
+                .map(|session| session.data.access_jwt),
+            Some("access".into())
+        );
+        assert_eq!(
+            counts.read().await.clone(),
+            HashMap::from_iter([
+                ("com.atproto.server.refreshSession".into(), 1),
+                ("com.atproto.server.getSession".into(), 3)
+            ])
+        );
+    }
+
+    #[tokio::test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    async fn test_resume_session() {
+        let session_data = session_data();
+        // success
+        {
+            let client = MockClient {
+                responses: MockResponses {
+                    get_session: Some(crate::com::atproto::server::get_session::OutputData {
+                        active: session_data.active,
+                        did: session_data.did.clone(),
+                        did_doc: session_data.did_doc.clone(),
+                        email: session_data.email.clone(),
+                        email_auth_factor: session_data.email_auth_factor,
+                        email_confirmed: session_data.email_confirmed,
+                        handle: session_data.handle.clone(),
+                        status: session_data.status.clone(),
+                    }),
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let agent = AtpAgent::new(client, MemorySessionStore::default());
+            assert_eq!(agent.get_session().await, None);
+            agent
+                .resume_session(
+                    OutputData {
+                        email: Some(String::from("test@example.com")),
+                        ..session_data.clone()
+                    }
+                    .into(),
+                )
+                .await
+                .expect("resume_session should be succeeded");
+            assert_eq!(agent.get_session().await, Some(session_data.clone().into()));
+        }
+        // failure with `getSession` error
+        {
+            let client = MockClient {
+                responses: MockResponses { ..Default::default() },
+                ..Default::default()
+            };
+            let agent = AtpAgent::new(client, MemorySessionStore::default());
+            assert_eq!(agent.get_session().await, None);
+            agent
+                .resume_session(session_data.clone().into())
+                .await
+                .expect_err("resume_session should be failed");
+            assert_eq!(agent.get_session().await, None);
+        }
+    }
+
+    #[tokio::test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    async fn test_resume_session_with_refresh() {
+        let session_data = session_data();
+        let client = MockClient {
+            responses: MockResponses {
+                get_session: Some(crate::com::atproto::server::get_session::OutputData {
+                    active: session_data.active,
+                    did: session_data.did.clone(),
+                    did_doc: session_data.did_doc.clone(),
+                    email: session_data.email.clone(),
+                    email_auth_factor: session_data.email_auth_factor,
+                    email_confirmed: session_data.email_confirmed,
+                    handle: session_data.handle.clone(),
+                    status: session_data.status.clone(),
+                }),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let agent = AtpAgent::new(client, MemorySessionStore::default());
+        agent
+            .resume_session(
+                OutputData { access_jwt: "expired".into(), ..session_data.clone() }.into(),
+            )
+            .await
+            .expect("resume_session should be succeeded");
+        assert_eq!(agent.get_session().await, Some(session_data.clone().into()));
+    }
+
+    #[tokio::test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    async fn test_login_with_diddoc() {
+        let session_data = session_data();
+        let did_doc = DidDocument {
+            context: None,
+            id: "did:plc:ewvi7nxzyoun6zhxrhs64oiz".into(),
+            also_known_as: Some(vec!["at://atproto.com".into()]),
+            verification_method: Some(vec![VerificationMethod {
+                id: "did:plc:ewvi7nxzyoun6zhxrhs64oiz#atproto".into(),
+                r#type: "Multikey".into(),
+                controller: "did:plc:ewvi7nxzyoun6zhxrhs64oiz".into(),
+                public_key_multibase: Some(
+                    "zQ3shXjHeiBuRCKmM36cuYnm7YEMzhGnCmCyW92sRJ9pribSF".into(),
+                ),
+            }]),
+            service: Some(vec![Service {
+                id: "#atproto_pds".into(),
+                r#type: "AtprotoPersonalDataServer".into(),
+                service_endpoint: "https://bsky.social".into(),
+            }]),
+        };
+        // success
+        {
+            let client = MockClient {
+                responses: MockResponses {
+                    create_session: Some(crate::com::atproto::server::create_session::OutputData {
+                        did_doc: Some(
+                            did_doc
+                                .clone()
+                                .try_into_unknown()
+                                .expect("failed to convert to unknown"),
+                        ),
+                        ..session_data.clone()
+                    }),
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let agent = AtpAgent::new(client, MemorySessionStore::default());
+            agent.login("test", "pass").await.expect("login should be succeeded");
+            assert_eq!(agent.get_endpoint().await, "https://bsky.social");
+            assert_eq!(agent.api.com.atproto.server.xrpc.base_uri(), "https://bsky.social");
+        }
+        // invalid services
+        {
+            let client = MockClient {
+                responses: MockResponses {
+                    create_session: Some(crate::com::atproto::server::create_session::OutputData {
+                        did_doc: Some(
+                            DidDocument {
+                                service: Some(vec![
+                                    Service {
+                                        id: "#pds".into(), // not `#atproto_pds`
+                                        r#type: "AtprotoPersonalDataServer".into(),
+                                        service_endpoint: "https://bsky.social".into(),
+                                    },
+                                    Service {
+                                        id: "#atproto_pds".into(),
+                                        r#type: "AtprotoPersonalDataServer".into(),
+                                        service_endpoint: "htps://bsky.social".into(), // invalid url (not `https`)
+                                    },
+                                ]),
+                                ..did_doc.clone()
+                            }
+                            .try_into_unknown()
+                            .expect("failed to convert to unknown"),
+                        ),
+                        ..session_data.clone()
+                    }),
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let agent = AtpAgent::new(client, MemorySessionStore::default());
+            agent.login("test", "pass").await.expect("login should be succeeded");
+            // not updated
+            assert_eq!(agent.get_endpoint().await, "http://localhost:8080");
+            assert_eq!(agent.api.com.atproto.server.xrpc.base_uri(), "http://localhost:8080");
+        }
+    }
+
+    #[tokio::test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    async fn test_configure_labelers_header() {
+        let client = MockClient::default();
+        let headers = Arc::clone(&client.headers);
+        let agent = AtpAgent::new(client, MemorySessionStore::default());
+
+        agent
+            .api
+            .com
+            .atproto
+            .server
+            .describe_server()
+            .await
+            .expect("describe_server should be succeeded");
+        assert_eq!(headers.read().await.last(), Some(&HeaderMap::new()));
+
+        agent.configure_labelers_header(Some(vec![(
+            "did:plc:test1".parse().expect("did should be valid"),
+            false,
+        )]));
+        agent
+            .api
+            .com
+            .atproto
+            .server
+            .describe_server()
+            .await
+            .expect("describe_server should be succeeded");
+        assert_eq!(
+            headers.read().await.last(),
+            Some(&HeaderMap::from_iter([(
+                HeaderName::from_static("atproto-accept-labelers"),
+                HeaderValue::from_static("did:plc:test1"),
+            )]))
+        );
+
+        agent.configure_labelers_header(Some(vec![
+            ("did:plc:test1".parse().expect("did should be valid"), true),
+            ("did:plc:test2".parse().expect("did should be valid"), false),
+        ]));
+        agent
+            .api
+            .com
+            .atproto
+            .server
+            .describe_server()
+            .await
+            .expect("describe_server should be succeeded");
+        assert_eq!(
+            headers.read().await.last(),
+            Some(&HeaderMap::from_iter([(
+                HeaderName::from_static("atproto-accept-labelers"),
+                HeaderValue::from_static("did:plc:test1;redact, did:plc:test2"),
+            )]))
+        );
+
+        assert_eq!(
+            agent.get_labelers_header().await,
+            Some(vec![String::from("did:plc:test1;redact"), String::from("did:plc:test2")])
+        );
+    }
+
+    #[tokio::test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    async fn test_configure_proxy_header() {
+        let client = MockClient::default();
+        let headers = Arc::clone(&client.headers);
+        let agent = AtpAgent::new(client, MemorySessionStore::default());
+
+        agent
+            .api
+            .com
+            .atproto
+            .server
+            .describe_server()
+            .await
+            .expect("describe_server should be succeeded");
+        assert_eq!(headers.read().await.last(), Some(&HeaderMap::new()));
+
+        agent.configure_proxy_header(
+            "did:plc:test1".parse().expect("did should be valid"),
+            AtprotoServiceType::AtprotoLabeler,
+        );
+        agent
+            .api
+            .com
+            .atproto
+            .server
+            .describe_server()
+            .await
+            .expect("describe_server should be succeeded");
+        assert_eq!(
+            headers.read().await.last(),
+            Some(&HeaderMap::from_iter([(
+                HeaderName::from_static("atproto-proxy"),
+                HeaderValue::from_static("did:plc:test1#atproto_labeler"),
+            ),]))
+        );
+
+        agent.configure_proxy_header(
+            "did:plc:test1".parse().expect("did should be valid"),
+            "atproto_labeler",
+        );
+        agent
+            .api
+            .com
+            .atproto
+            .server
+            .describe_server()
+            .await
+            .expect("describe_server should be succeeded");
+        assert_eq!(
+            headers.read().await.last(),
+            Some(&HeaderMap::from_iter([(
+                HeaderName::from_static("atproto-proxy"),
+                HeaderValue::from_static("did:plc:test1#atproto_labeler"),
+            ),]))
+        );
+
+        agent
+            .api_with_proxy(
+                "did:plc:test2".parse().expect("did should be valid"),
+                "atproto_labeler",
+            )
+            .com
+            .atproto
+            .server
+            .describe_server()
+            .await
+            .expect("describe_server should be succeeded");
+        assert_eq!(
+            headers.read().await.last(),
+            Some(&HeaderMap::from_iter([(
+                HeaderName::from_static("atproto-proxy"),
+                HeaderValue::from_static("did:plc:test2#atproto_labeler"),
+            ),]))
+        );
+
+        agent
+            .api
+            .com
+            .atproto
+            .server
+            .describe_server()
+            .await
+            .expect("describe_server should be succeeded");
+        assert_eq!(
+            headers.read().await.last(),
+            Some(&HeaderMap::from_iter([(
+                HeaderName::from_static("atproto-proxy"),
+                HeaderValue::from_static("did:plc:test1#atproto_labeler"),
+            ),]))
+        );
+
+        assert_eq!(
+            agent.get_proxy_header().await,
+            Some(String::from("did:plc:test1#atproto_labeler"))
+        );
+    }
+
+    #[tokio::test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    async fn test_agent_did() {
+        let session_data = session_data();
+        let client = MockClient { responses: MockResponses::default(), ..Default::default() };
+        let agent = AtpAgent::new(client, MemorySessionStore::default());
+        assert_eq!(agent.did().await, None);
+        agent
+            .session_manager
+            .store
+            .set(session_data.clone().into())
+            .await
+            .expect("set session should be succeeded");
+        assert_eq!(agent.did().await, Some(session_data.did));
+    }
+}

--- a/atrium-api/src/agent/atp_agent/inner.rs
+++ b/atrium-api/src/agent/atp_agent/inner.rs
@@ -1,0 +1,196 @@
+use super::{AtpSession, AtpSessionStore};
+use crate::{
+    agent::{
+        utils::{SessionClient, SessionWithEndpointStore},
+        CloneWithProxy, Configure,
+    },
+    did_doc::DidDocument,
+    types::{string::Did, TryFromUnknown},
+};
+use atrium_xrpc::{
+    error::{Error, Result, XrpcErrorKind},
+    {HttpClient, OutputDataOrBytes, XrpcClient, XrpcRequest},
+};
+use http::{Method, Request, Response};
+use serde::{de::DeserializeOwned, Serialize};
+use std::{fmt::Debug, sync::Arc};
+use tokio::sync::{Mutex, Notify};
+
+pub struct Client<S, T> {
+    store: Arc<SessionWithEndpointStore<S, AtpSession>>,
+    inner: SessionClient<S, T, AtpSession>,
+    is_refreshing: Arc<Mutex<bool>>,
+    notify: Arc<Notify>,
+}
+
+impl<S, T> Client<S, T>
+where
+    S: AtpSessionStore + Send + Sync,
+    T: HttpClient + Send + Sync,
+    S::Error: std::error::Error + Send + Sync + 'static,
+{
+    pub fn new(store: Arc<SessionWithEndpointStore<S, AtpSession>>, http_client: T) -> Self {
+        let inner = SessionClient::new(Arc::clone(&store), http_client);
+        Self {
+            store,
+            inner,
+            is_refreshing: Arc::new(Mutex::new(false)),
+            notify: Arc::new(Notify::new()),
+        }
+    }
+    pub async fn get_labelers_header(&self) -> Option<Vec<String>> {
+        self.inner.atproto_accept_labelers_header().await
+    }
+    pub async fn get_proxy_header(&self) -> Option<String> {
+        self.inner.atproto_proxy_header().await
+    }
+    // Internal helper to refresh sessions
+    // - Wraps the actual implementation to ensure only one refresh is attempted at a time.
+    async fn refresh_session(&self) {
+        {
+            let mut is_refreshing = self.is_refreshing.lock().await;
+            if *is_refreshing {
+                drop(is_refreshing);
+                return self.notify.notified().await;
+            }
+            *is_refreshing = true;
+        }
+        // TODO: Ensure `is_refreshing` is reliably set to false even in the event of unexpected errors within `refresh_session_inner()`.
+        self.refresh_session_inner().await;
+        *self.is_refreshing.lock().await = false;
+        self.notify.notify_waiters();
+    }
+    async fn refresh_session_inner(&self) {
+        if let Ok(output) = self.call_refresh_session().await {
+            if let Ok(Some(mut session)) = self.store.get().await {
+                session.access_jwt = output.data.access_jwt;
+                session.did = output.data.did;
+                session.did_doc = output.data.did_doc.clone();
+                session.handle = output.data.handle;
+                session.refresh_jwt = output.data.refresh_jwt;
+                self.store.set(session).await.ok();
+            }
+            if let Some(did_doc) = output
+                .data
+                .did_doc
+                .as_ref()
+                .and_then(|value| DidDocument::try_from_unknown(value.clone()).ok())
+            {
+                self.store.update_endpoint(&did_doc);
+            }
+        } else {
+            self.store.clear().await.ok();
+        }
+    }
+    // same as `crate::client::com::atproto::server::Service::refresh_session()`
+    async fn call_refresh_session(
+        &self,
+    ) -> Result<
+        crate::com::atproto::server::refresh_session::Output,
+        crate::com::atproto::server::refresh_session::Error,
+    > {
+        let response = self
+            .inner
+            .send_xrpc::<(), (), _, _>(&XrpcRequest {
+                method: Method::POST,
+                nsid: crate::com::atproto::server::refresh_session::NSID.into(),
+                parameters: None,
+                input: None,
+                encoding: None,
+            })
+            .await?;
+        match response {
+            OutputDataOrBytes::Data(data) => Ok(data),
+            _ => Err(Error::UnexpectedResponseType),
+        }
+    }
+    fn is_expired<O, E>(result: &Result<OutputDataOrBytes<O>, E>) -> bool
+    where
+        O: DeserializeOwned + Send + Sync,
+        E: DeserializeOwned + Send + Sync + Debug,
+    {
+        if let Err(Error::XrpcResponse(response)) = &result {
+            if let Some(XrpcErrorKind::Undefined(body)) = &response.error {
+                if let Some("ExpiredToken") = &body.error.as_deref() {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+}
+
+impl<S, T> Configure for Client<S, T> {
+    fn configure_endpoint(&self, endpoint: String) {
+        *self.store.endpoint.write().expect("failed to write endpoint") = endpoint;
+    }
+    fn configure_labelers_header(&self, labeler_dids: Option<Vec<(Did, bool)>>) {
+        self.inner.configure_labelers_header(labeler_dids);
+    }
+    fn configure_proxy_header(&self, did: Did, service_type: impl AsRef<str>) {
+        self.inner.configure_proxy_header(did, service_type);
+    }
+}
+
+impl<S, T> CloneWithProxy for Client<S, T> {
+    fn clone_with_proxy(&self, did: Did, service_type: impl AsRef<str>) -> Self {
+        let cloned = self.clone();
+        cloned.inner.configure_proxy_header(did, service_type);
+        cloned
+    }
+}
+
+impl<S, T> Clone for Client<S, T> {
+    fn clone(&self) -> Self {
+        Self {
+            store: self.store.clone(),
+            inner: self.inner.clone(),
+            is_refreshing: self.is_refreshing.clone(),
+            notify: self.notify.clone(),
+        }
+    }
+}
+
+impl<S, T> HttpClient for Client<S, T>
+where
+    S: AtpSessionStore + Send + Sync,
+    T: HttpClient + Send + Sync,
+{
+    async fn send_http(
+        &self,
+        request: Request<Vec<u8>>,
+    ) -> core::result::Result<Response<Vec<u8>>, Box<dyn std::error::Error + Send + Sync + 'static>>
+    {
+        self.inner.send_http(request).await
+    }
+}
+
+impl<S, T> XrpcClient for Client<S, T>
+where
+    S: AtpSessionStore + Send + Sync,
+    T: XrpcClient + Send + Sync,
+    S::Error: std::error::Error + Send + Sync + 'static,
+{
+    fn base_uri(&self) -> String {
+        self.inner.base_uri()
+    }
+    async fn send_xrpc<P, I, O, E>(
+        &self,
+        request: &XrpcRequest<P, I>,
+    ) -> Result<OutputDataOrBytes<O>, E>
+    where
+        P: Serialize + Send + Sync,
+        I: Serialize + Send + Sync,
+        O: DeserializeOwned + Send + Sync,
+        E: DeserializeOwned + Send + Sync + Debug,
+    {
+        let result = self.inner.send_xrpc(request).await;
+        // handle session-refreshes as needed
+        if Self::is_expired(&result) {
+            self.refresh_session().await;
+            self.inner.send_xrpc(request).await
+        } else {
+            result
+        }
+    }
+}

--- a/atrium-api/src/agent/atp_agent/store.rs
+++ b/atrium-api/src/agent/atp_agent/store.rs
@@ -1,0 +1,30 @@
+use super::AtpSession;
+use crate::agent::AuthorizationProvider;
+use atrium_common::store::{memory::MemoryStore, Store};
+use atrium_xrpc::types::AuthorizationToken;
+
+#[cfg_attr(not(target_arch = "wasm32"), trait_variant::make(Send))]
+pub trait AtpSessionStore: Store<(), AtpSession> + AuthorizationProvider {}
+
+pub type MemorySessionStore = MemoryStore<(), AtpSession>;
+
+impl AtpSessionStore for MemorySessionStore {}
+
+impl AuthorizationProvider for MemorySessionStore {
+    async fn authorization_token(&self, is_refresh: bool) -> Option<AuthorizationToken> {
+        self.get(&())
+            .await
+            .ok()
+            .flatten()
+            .map(
+                |session| {
+                    if is_refresh {
+                        session.refresh_jwt.clone()
+                    } else {
+                        session.access_jwt.clone()
+                    }
+                },
+            )
+            .map(AuthorizationToken::Bearer)
+    }
+}

--- a/atrium-api/src/agent/inner.rs
+++ b/atrium-api/src/agent/inner.rs
@@ -1,253 +1,38 @@
-use super::{Session, SessionStore};
-use crate::did_doc::DidDocument;
-use crate::types::{string::Did, TryFromUnknown};
-use atrium_xrpc::{
-    error::{Error, Result, XrpcErrorKind},
-    types::AuthorizationToken,
-    HttpClient, OutputDataOrBytes, XrpcClient, XrpcRequest,
-};
-use http::{Method, Request, Response};
+use super::{CloneWithProxy, Configure, SessionManager};
+use crate::types::string::Did;
+use atrium_xrpc::{Error, HttpClient, OutputDataOrBytes, XrpcClient, XrpcRequest};
+use http::{Request, Response};
 use serde::{de::DeserializeOwned, Serialize};
-use std::{
-    fmt::Debug,
-    sync::{Arc, RwLock},
-};
-use tokio::sync::{Mutex, Notify};
+use std::{fmt::Debug, ops::Deref, sync::Arc};
 
-struct WrapperClient<S, T> {
-    store: Arc<Store<S>>,
-    proxy_header: RwLock<Option<String>>,
-    labelers_header: Arc<RwLock<Option<Vec<String>>>>,
-    inner: Arc<T>,
+pub struct Wrapper<M> {
+    inner: Arc<M>,
 }
 
-impl<S, T> WrapperClient<S, T> {
-    fn configure_proxy_header(&self, value: String) {
-        self.proxy_header.write().expect("failed to write proxy header").replace(value);
-    }
-    fn configure_labelers_header(&self, labelers_dids: Option<Vec<(Did, bool)>>) {
-        *self.labelers_header.write().expect("failed to write labelers header") =
-            labelers_dids.map(|dids| {
-                dids.iter()
-                    .map(|(did, redact)| {
-                        if *redact {
-                            format!("{};redact", did.as_ref())
-                        } else {
-                            did.as_ref().into()
-                        }
-                    })
-                    .collect()
-            })
-    }
-}
-
-impl<S, T> Clone for WrapperClient<S, T> {
-    fn clone(&self) -> Self {
-        Self {
-            store: self.store.clone(),
-            labelers_header: self.labelers_header.clone(),
-            proxy_header: RwLock::new(
-                self.proxy_header.read().expect("failed to read proxy header").clone(),
-            ),
-            inner: self.inner.clone(),
-        }
-    }
-}
-
-impl<S, T> HttpClient for WrapperClient<S, T>
+impl<M> Wrapper<M>
 where
-    S: Send + Sync,
-    T: HttpClient + Send + Sync,
+    M: SessionManager + Send + Sync,
+{
+    pub fn new(inner: M) -> Self {
+        Self { inner: Arc::new(inner) }
+    }
+}
+
+impl<M> HttpClient for Wrapper<M>
+where
+    M: SessionManager + Send + Sync,
 {
     async fn send_http(
         &self,
         request: Request<Vec<u8>>,
-    ) -> core::result::Result<Response<Vec<u8>>, Box<dyn std::error::Error + Send + Sync + 'static>>
-    {
+    ) -> Result<Response<Vec<u8>>, Box<dyn std::error::Error + Send + Sync + 'static>> {
         self.inner.send_http(request).await
     }
 }
 
-impl<S, T> XrpcClient for WrapperClient<S, T>
+impl<M> XrpcClient for Wrapper<M>
 where
-    S: SessionStore + Send + Sync,
-    T: XrpcClient + Send + Sync,
-{
-    fn base_uri(&self) -> String {
-        self.store.get_endpoint()
-    }
-    async fn authorization_token(&self, is_refresh: bool) -> Option<AuthorizationToken> {
-        self.store.get_session().await.map(|session| {
-            AuthorizationToken::Bearer(if is_refresh {
-                session.data.refresh_jwt
-            } else {
-                session.data.access_jwt
-            })
-        })
-    }
-    async fn atproto_proxy_header(&self) -> Option<String> {
-        self.proxy_header.read().expect("failed to read proxy header").clone()
-    }
-    async fn atproto_accept_labelers_header(&self) -> Option<Vec<String>> {
-        self.labelers_header.read().expect("failed to read labelers header").clone()
-    }
-}
-
-pub struct Client<S, T> {
-    store: Arc<Store<S>>,
-    inner: WrapperClient<S, T>,
-    is_refreshing: Arc<Mutex<bool>>,
-    notify: Arc<Notify>,
-}
-
-impl<S, T> Client<S, T>
-where
-    S: SessionStore + Send + Sync,
-    T: XrpcClient + Send + Sync,
-{
-    pub fn new(store: Arc<Store<S>>, xrpc: T) -> Self {
-        let inner = WrapperClient {
-            store: Arc::clone(&store),
-            labelers_header: Arc::new(RwLock::new(None)),
-            proxy_header: RwLock::new(None),
-            inner: Arc::new(xrpc),
-        };
-        Self {
-            store,
-            inner,
-            is_refreshing: Arc::new(Mutex::new(false)),
-            notify: Arc::new(Notify::new()),
-        }
-    }
-    pub fn configure_endpoint(&self, endpoint: String) {
-        *self.store.endpoint.write().expect("failed to write endpoint") = endpoint;
-    }
-    pub fn configure_proxy_header(&self, did: Did, service_type: impl AsRef<str>) {
-        self.inner.configure_proxy_header(format!("{}#{}", did.as_ref(), service_type.as_ref()));
-    }
-    pub fn clone_with_proxy(&self, did: Did, service_type: impl AsRef<str>) -> Self {
-        let cloned = self.clone();
-        cloned.inner.configure_proxy_header(format!("{}#{}", did.as_ref(), service_type.as_ref()));
-        cloned
-    }
-    pub fn configure_labelers_header(&self, labeler_dids: Option<Vec<(Did, bool)>>) {
-        self.inner.configure_labelers_header(labeler_dids);
-    }
-    pub async fn get_labelers_header(&self) -> Option<Vec<String>> {
-        self.inner.atproto_accept_labelers_header().await
-    }
-    pub async fn get_proxy_header(&self) -> Option<String> {
-        self.inner.atproto_proxy_header().await
-    }
-    // Internal helper to refresh sessions
-    // - Wraps the actual implementation to ensure only one refresh is attempted at a time.
-    async fn refresh_session(&self) {
-        {
-            let mut is_refreshing = self.is_refreshing.lock().await;
-            if *is_refreshing {
-                drop(is_refreshing);
-                return self.notify.notified().await;
-            }
-            *is_refreshing = true;
-        }
-        // TODO: Ensure `is_refreshing` is reliably set to false even in the event of unexpected errors within `refresh_session_inner()`.
-        self.refresh_session_inner().await;
-        *self.is_refreshing.lock().await = false;
-        self.notify.notify_waiters();
-    }
-    async fn refresh_session_inner(&self) {
-        if let Ok(output) = self.call_refresh_session().await {
-            if let Some(mut session) = self.store.get_session().await {
-                session.access_jwt = output.data.access_jwt;
-                session.did = output.data.did;
-                session.did_doc = output.data.did_doc.clone();
-                session.handle = output.data.handle;
-                session.refresh_jwt = output.data.refresh_jwt;
-                self.store.set_session(session).await;
-            }
-            if let Some(did_doc) = output
-                .data
-                .did_doc
-                .as_ref()
-                .and_then(|value| DidDocument::try_from_unknown(value.clone()).ok())
-            {
-                self.store.update_endpoint(&did_doc);
-            }
-        } else {
-            self.store.clear_session().await;
-        }
-    }
-    // same as `crate::client::com::atproto::server::Service::refresh_session()`
-    async fn call_refresh_session(
-        &self,
-    ) -> Result<
-        crate::com::atproto::server::refresh_session::Output,
-        crate::com::atproto::server::refresh_session::Error,
-    > {
-        let response = self
-            .inner
-            .send_xrpc::<(), (), _, _>(&XrpcRequest {
-                method: Method::POST,
-                nsid: crate::com::atproto::server::refresh_session::NSID.into(),
-                parameters: None,
-                input: None,
-                encoding: None,
-            })
-            .await?;
-        match response {
-            OutputDataOrBytes::Data(data) => Ok(data),
-            _ => Err(Error::UnexpectedResponseType),
-        }
-    }
-    fn is_expired<O, E>(result: &Result<OutputDataOrBytes<O>, E>) -> bool
-    where
-        O: DeserializeOwned + Send + Sync,
-        E: DeserializeOwned + Send + Sync + Debug,
-    {
-        if let Err(Error::XrpcResponse(response)) = &result {
-            if let Some(XrpcErrorKind::Undefined(body)) = &response.error {
-                if let Some("ExpiredToken") = &body.error.as_deref() {
-                    return true;
-                }
-            }
-        }
-        false
-    }
-}
-
-impl<S, T> Clone for Client<S, T>
-where
-    S: SessionStore + Send + Sync,
-    T: XrpcClient + Send + Sync,
-{
-    fn clone(&self) -> Self {
-        Self {
-            store: self.store.clone(),
-            inner: self.inner.clone(),
-            is_refreshing: self.is_refreshing.clone(),
-            notify: self.notify.clone(),
-        }
-    }
-}
-
-impl<S, T> HttpClient for Client<S, T>
-where
-    S: Send + Sync,
-    T: HttpClient + Send + Sync,
-{
-    async fn send_http(
-        &self,
-        request: Request<Vec<u8>>,
-    ) -> core::result::Result<Response<Vec<u8>>, Box<dyn std::error::Error + Send + Sync + 'static>>
-    {
-        self.inner.send_http(request).await
-    }
-}
-
-impl<S, T> XrpcClient for Client<S, T>
-where
-    S: SessionStore + Send + Sync,
-    T: XrpcClient + Send + Sync,
+    M: SessionManager + Send + Sync,
 {
     fn base_uri(&self) -> String {
         self.inner.base_uri()
@@ -255,54 +40,66 @@ where
     async fn send_xrpc<P, I, O, E>(
         &self,
         request: &XrpcRequest<P, I>,
-    ) -> Result<OutputDataOrBytes<O>, E>
+    ) -> Result<OutputDataOrBytes<O>, Error<E>>
     where
         P: Serialize + Send + Sync,
         I: Serialize + Send + Sync,
         O: DeserializeOwned + Send + Sync,
         E: DeserializeOwned + Send + Sync + Debug,
     {
-        let result = self.inner.send_xrpc(request).await;
-        // handle session-refreshes as needed
-        if Self::is_expired(&result) {
-            self.refresh_session().await;
-            self.inner.send_xrpc(request).await
-        } else {
-            result
-        }
+        self.inner.send_xrpc(request).await
     }
 }
 
-pub struct Store<S> {
-    inner: S,
-    endpoint: RwLock<String>,
-}
-
-impl<S> Store<S> {
-    pub fn new(inner: S, initial_endpoint: String) -> Self {
-        Self { inner, endpoint: RwLock::new(initial_endpoint) }
-    }
-    pub fn get_endpoint(&self) -> String {
-        self.endpoint.read().expect("failed to read endpoint").clone()
-    }
-    pub fn update_endpoint(&self, did_doc: &DidDocument) {
-        if let Some(endpoint) = did_doc.get_pds_endpoint() {
-            *self.endpoint.write().expect("failed to write endpoint") = endpoint;
-        }
-    }
-}
-
-impl<S> SessionStore for Store<S>
+impl<M> SessionManager for Wrapper<M>
 where
-    S: SessionStore + Send + Sync,
+    M: SessionManager + Send + Sync,
 {
-    async fn get_session(&self) -> Option<Session> {
-        self.inner.get_session().await
+    async fn did(&self) -> Option<Did> {
+        self.inner.did().await
     }
-    async fn set_session(&self, session: Session) {
-        self.inner.set_session(session).await;
+}
+
+impl<M> Configure for Wrapper<M>
+where
+    M: Configure,
+{
+    fn configure_endpoint(&self, endpoint: String) {
+        self.inner.configure_endpoint(endpoint);
     }
-    async fn clear_session(&self) {
-        self.inner.clear_session().await;
+    fn configure_labelers_header(&self, labeler_dids: Option<Vec<(Did, bool)>>) {
+        self.inner.configure_labelers_header(labeler_dids);
+    }
+    fn configure_proxy_header(&self, did: Did, service_type: impl AsRef<str>) {
+        self.inner.configure_proxy_header(did, service_type);
+    }
+}
+
+impl<M> CloneWithProxy for Wrapper<M>
+where
+    M: CloneWithProxy,
+{
+    fn clone_with_proxy(&self, did: Did, service_type: impl AsRef<str>) -> Self {
+        Self { inner: Arc::new(self.inner.clone_with_proxy(did, service_type)) }
+    }
+}
+
+impl<M> Clone for Wrapper<M>
+where
+    M: SessionManager + Send + Sync,
+{
+    fn clone(&self) -> Self {
+        Self { inner: self.inner.clone() }
+    }
+}
+
+impl<M> Deref for Wrapper<M>
+where
+    M: SessionManager + Send + Sync,
+{
+    type Target = M;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
 }

--- a/atrium-api/src/agent/session_manager.rs
+++ b/atrium-api/src/agent/session_manager.rs
@@ -1,0 +1,8 @@
+use crate::types::string::Did;
+use atrium_xrpc::XrpcClient;
+use std::future::Future;
+
+#[cfg_attr(not(target_arch = "wasm32"), trait_variant::make(Send))]
+pub trait SessionManager: XrpcClient {
+    fn did(&self) -> impl Future<Output = Option<Did>>;
+}

--- a/atrium-api/src/agent/session_manager.rs
+++ b/atrium-api/src/agent/session_manager.rs
@@ -2,6 +2,9 @@ use crate::types::string::Did;
 use atrium_xrpc::XrpcClient;
 use std::future::Future;
 
+/// A trait for managing sessions.
+///
+/// [`Agent`](crate::agent::Agent) creation requires an implementation of this `SessionManager`.
 #[cfg_attr(not(target_arch = "wasm32"), trait_variant::make(Send))]
 pub trait SessionManager: XrpcClient {
     fn did(&self) -> impl Future<Output = Option<Did>>;

--- a/atrium-api/src/agent/utils.rs
+++ b/atrium-api/src/agent/utils.rs
@@ -1,3 +1,5 @@
+//! Utilities for managing sessions and endpoints.
+
 use super::{AuthorizationProvider, CloneWithProxy, Configure};
 use crate::{did_doc::DidDocument, types::string::Did};
 use atrium_common::store::Store;
@@ -9,6 +11,7 @@ use std::{
 };
 
 /// A client that maintains session data and manages endpoints and XRPC headers.  
+///
 /// It is recommended to use this struct internally in higher-level clients such as [`XrpcClient`], which can automatically update tokens.
 pub struct SessionClient<S, T, U> {
     store: Arc<SessionWithEndpointStore<S, U>>,
@@ -111,7 +114,8 @@ where
     }
 }
 
-/// A store that wraps an underlying store providing authorization token and adds endpoint management functionality.  
+/// A store that wraps an underlying store providing authorization token and adds endpoint management functionality.
+///
 /// This struct is intended to be used when creating a [`SessionClient`].
 pub struct SessionWithEndpointStore<S, U> {
     inner: S,

--- a/atrium-api/src/agent/utils.rs
+++ b/atrium-api/src/agent/utils.rs
@@ -1,0 +1,160 @@
+use super::{AuthorizationProvider, CloneWithProxy, Configure};
+use crate::{did_doc::DidDocument, types::string::Did};
+use atrium_common::store::Store;
+use atrium_xrpc::{types::AuthorizationToken, HttpClient, XrpcClient};
+use http::{Request, Response};
+use std::{
+    marker::PhantomData,
+    sync::{Arc, RwLock},
+};
+
+/// A client that maintains session data and manages endpoints and XRPC headers.  
+/// It is recommended to use this struct internally in higher-level clients such as [`XrpcClient`], which can automatically update tokens.
+pub struct SessionClient<S, T, U> {
+    store: Arc<SessionWithEndpointStore<S, U>>,
+    proxy_header: RwLock<Option<String>>,
+    labelers_header: Arc<RwLock<Option<Vec<String>>>>,
+    inner: Arc<T>,
+}
+
+impl<S, T, U> SessionClient<S, T, U> {
+    pub fn new(store: Arc<SessionWithEndpointStore<S, U>>, http_client: T) -> Self {
+        Self {
+            store: Arc::clone(&store),
+            labelers_header: Arc::new(RwLock::new(None)),
+            proxy_header: RwLock::new(None),
+            inner: Arc::new(http_client),
+        }
+    }
+}
+
+impl<S, T, U> Configure for SessionClient<S, T, U> {
+    fn configure_endpoint(&self, endpoint: String) {
+        *self.store.endpoint.write().expect("failed to write endpoint") = endpoint;
+    }
+    fn configure_labelers_header(&self, labelers_dids: Option<Vec<(Did, bool)>>) {
+        *self.labelers_header.write().expect("failed to write labelers header") =
+            labelers_dids.map(|dids| {
+                dids.iter()
+                    .map(|(did, redact)| {
+                        if *redact {
+                            format!("{};redact", did.as_ref())
+                        } else {
+                            did.as_ref().into()
+                        }
+                    })
+                    .collect()
+            })
+    }
+    fn configure_proxy_header(&self, did: Did, service_type: impl AsRef<str>) {
+        self.proxy_header.write().expect("failed to write proxy header").replace(format!(
+            "{}#{}",
+            did.as_ref(),
+            service_type.as_ref()
+        ));
+    }
+}
+
+impl<S, T, U> CloneWithProxy for SessionClient<S, T, U> {
+    fn clone_with_proxy(&self, did: Did, service_type: impl AsRef<str>) -> Self {
+        let cloned = self.clone();
+        cloned.configure_proxy_header(did, service_type);
+        cloned
+    }
+}
+
+impl<S, T, U> Clone for SessionClient<S, T, U> {
+    fn clone(&self) -> Self {
+        Self {
+            store: self.store.clone(),
+            labelers_header: self.labelers_header.clone(),
+            proxy_header: RwLock::new(
+                self.proxy_header.read().expect("failed to read proxy header").clone(),
+            ),
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<S, T, U> HttpClient for SessionClient<S, T, U>
+where
+    S: Store<(), U> + Send + Sync,
+    T: HttpClient + Send + Sync,
+    U: Clone + Send + Sync,
+{
+    async fn send_http(
+        &self,
+        request: Request<Vec<u8>>,
+    ) -> core::result::Result<Response<Vec<u8>>, Box<dyn std::error::Error + Send + Sync + 'static>>
+    {
+        self.inner.send_http(request).await
+    }
+}
+
+impl<S, T, U> XrpcClient for SessionClient<S, T, U>
+where
+    S: Store<(), U> + AuthorizationProvider + Send + Sync,
+    T: HttpClient + Send + Sync,
+    U: Clone + Send + Sync,
+{
+    fn base_uri(&self) -> String {
+        self.store.get_endpoint()
+    }
+    async fn authorization_token(&self, is_refresh: bool) -> Option<AuthorizationToken> {
+        self.store.authorization_token(is_refresh).await
+    }
+    async fn atproto_proxy_header(&self) -> Option<String> {
+        self.proxy_header.read().expect("failed to read proxy header").clone()
+    }
+    async fn atproto_accept_labelers_header(&self) -> Option<Vec<String>> {
+        self.labelers_header.read().expect("failed to read labelers header").clone()
+    }
+}
+
+/// A store that wraps an underlying store providing authorization token and adds endpoint management functionality.  
+/// This struct is intended to be used when creating a [`SessionClient`].
+pub struct SessionWithEndpointStore<S, U> {
+    inner: S,
+    pub endpoint: RwLock<String>,
+    _phantom: PhantomData<U>,
+}
+
+impl<S, U> SessionWithEndpointStore<S, U> {
+    pub fn new(inner: S, initial_endpoint: String) -> Self {
+        Self { inner, endpoint: RwLock::new(initial_endpoint), _phantom: PhantomData }
+    }
+    pub fn get_endpoint(&self) -> String {
+        self.endpoint.read().expect("failed to read endpoint").clone()
+    }
+    pub fn update_endpoint(&self, did_doc: &DidDocument) {
+        if let Some(endpoint) = did_doc.get_pds_endpoint() {
+            *self.endpoint.write().expect("failed to write endpoint") = endpoint;
+        }
+    }
+}
+
+impl<S, U> SessionWithEndpointStore<S, U>
+where
+    S: Store<(), U>,
+    U: Clone,
+{
+    pub async fn get(&self) -> Result<Option<U>, S::Error> {
+        self.inner.get(&()).await
+    }
+    pub async fn set(&self, value: U) -> Result<(), S::Error> {
+        self.inner.set((), value).await
+    }
+    pub async fn clear(&self) -> Result<(), S::Error> {
+        self.inner.clear().await
+    }
+}
+
+impl<S, U> AuthorizationProvider for SessionWithEndpointStore<S, U>
+where
+    S: Store<(), U> + AuthorizationProvider + Send + Sync,
+    U: Clone + Send + Sync,
+{
+    async fn authorization_token(&self, is_refresh: bool) -> Option<AuthorizationToken> {
+        self.inner.authorization_token(is_refresh).await
+    }
+}

--- a/atrium-xrpc/src/error.rs
+++ b/atrium-xrpc/src/error.rs
@@ -1,5 +1,5 @@
 #![doc = "Error types."]
-use http::StatusCode;
+use http::{HeaderValue, StatusCode};
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Debug, Display};
 
@@ -9,6 +9,8 @@ pub enum Error<E>
 where
     E: Debug,
 {
+    #[error("authentication error: {0:?}")]
+    Authentication(HeaderValue),
     #[error("xrpc response error: {0}")]
     XrpcResponse(XrpcError<E>),
     #[error("http request error: {0}")]

--- a/atrium-xrpc/src/traits.rs
+++ b/atrium-xrpc/src/traits.rs
@@ -1,7 +1,7 @@
 use crate::error::{Error, XrpcError, XrpcErrorKind};
 use crate::types::{AuthorizationToken, Header, NSID_REFRESH_SESSION};
 use crate::{InputDataOrBytes, OutputDataOrBytes, XrpcRequest};
-use http::{Method, Request, Response};
+use http::{header::WWW_AUTHENTICATE, Method, Request, Response};
 use serde::{de::DeserializeOwned, Serialize};
 use std::{fmt::Debug, future::Future};
 
@@ -137,6 +137,8 @@ where
         } else {
             Ok(OutputDataOrBytes::Bytes(body))
         }
+    } else if let Some(value) = parts.headers.get(WWW_AUTHENTICATE) {
+        Err(Error::Authentication(value.clone()))
     } else {
         Err(Error::XrpcResponse(XrpcError {
             status: parts.status,

--- a/bsky-sdk/Cargo.toml
+++ b/bsky-sdk/Cargo.toml
@@ -26,6 +26,7 @@ unicode-segmentation = { version = "1.11.0", optional = true }
 trait-variant.workspace = true
 
 [dev-dependencies]
+atrium-common.workspace = true
 ipld-core.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 

--- a/bsky-sdk/src/agent/builder.rs
+++ b/bsky-sdk/src/agent/builder.rs
@@ -1,25 +1,31 @@
 use super::config::Config;
 use super::BskyAgent;
 use crate::error::Result;
-use atrium_api::agent::store::MemorySessionStore;
-use atrium_api::agent::{store::SessionStore, AtpAgent};
+use atrium_api::agent::{
+    atp_agent::{
+        store::{AtpSessionStore, MemorySessionStore},
+        AtpAgent,
+    },
+    Configure,
+};
 use atrium_api::xrpc::XrpcClient;
 #[cfg(feature = "default-client")]
 use atrium_xrpc_client::reqwest::ReqwestClient;
 use std::sync::Arc;
 
-/// A builder for creating a [`BskyAgent`].
-pub struct BskyAgentBuilder<T, S = MemorySessionStore>
+/// A builder for creating a [`BskyAtpAgent`].
+pub struct BskyAtpAgentBuilder<T, S = MemorySessionStore>
 where
     T: XrpcClient + Send + Sync,
-    S: SessionStore + Send + Sync,
+    S: AtpSessionStore + Send + Sync,
+    S::Error: std::error::Error + Send + Sync + 'static,
 {
     config: Config,
     store: S,
     client: T,
 }
 
-impl<T> BskyAgentBuilder<T>
+impl<T> BskyAtpAgentBuilder<T>
 where
     T: XrpcClient + Send + Sync,
 {
@@ -29,10 +35,11 @@ where
     }
 }
 
-impl<T, S> BskyAgentBuilder<T, S>
+impl<T, S> BskyAtpAgentBuilder<T, S>
 where
     T: XrpcClient + Send + Sync,
-    S: SessionStore + Send + Sync,
+    S: AtpSessionStore + Send + Sync,
+    S::Error: std::error::Error + Send + Sync + 'static,
 {
     /// Set the configuration for the agent.
     pub fn config(mut self, config: Config) -> Self {
@@ -42,20 +49,21 @@ where
     /// Set the session store for the agent.
     ///
     /// Returns a new builder with the session store set.
-    pub fn store<S0>(self, store: S0) -> BskyAgentBuilder<T, S0>
+    pub fn store<S0>(self, store: S0) -> BskyAtpAgentBuilder<T, S0>
     where
-        S0: SessionStore + Send + Sync,
+        S0: AtpSessionStore + Send + Sync,
+        S0::Error: std::error::Error + Send + Sync + 'static,
     {
-        BskyAgentBuilder { config: self.config, store, client: self.client }
+        BskyAtpAgentBuilder { config: self.config, store, client: self.client }
     }
     /// Set the XRPC client for the agent.
     ///
     /// Returns a new builder with the XRPC client set.
-    pub fn client<T0>(self, client: T0) -> BskyAgentBuilder<T0, S>
+    pub fn client<T0>(self, client: T0) -> BskyAtpAgentBuilder<T0, S>
     where
         T0: XrpcClient + Send + Sync,
     {
-        BskyAgentBuilder { config: self.config, store: self.store, client }
+        BskyAtpAgentBuilder { config: self.config, store: self.store, client }
     }
     pub async fn build(self) -> Result<BskyAgent<T, S>> {
         let agent = AtpAgent::new(self.client, self.store);
@@ -91,7 +99,7 @@ where
 
 #[cfg_attr(docsrs, doc(cfg(feature = "default-client")))]
 #[cfg(feature = "default-client")]
-impl Default for BskyAgentBuilder<ReqwestClient, MemorySessionStore> {
+impl Default for BskyAtpAgentBuilder<ReqwestClient, MemorySessionStore> {
     /// Create a new builder with the default client and session store.
     ///
     /// Default client is [`ReqwestClient`] and default session store is [`MemorySessionStore`].
@@ -103,47 +111,20 @@ impl Default for BskyAgentBuilder<ReqwestClient, MemorySessionStore> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use atrium_api::agent::Session;
-    use atrium_api::com::atproto::server::create_session::OutputData;
-
-    fn session() -> Session {
-        OutputData {
-            access_jwt: String::new(),
-            active: None,
-            did: "did:fake:handle.test".parse().expect("invalid did"),
-            did_doc: None,
-            email: None,
-            email_auth_factor: None,
-            email_confirmed: None,
-            handle: "handle.test".parse().expect("invalid handle"),
-            refresh_jwt: String::new(),
-            status: None,
-        }
-        .into()
-    }
-
-    struct MockSessionStore;
-
-    impl SessionStore for MockSessionStore {
-        async fn get_session(&self) -> Option<Session> {
-            Some(session())
-        }
-        async fn set_session(&self, _: Session) {}
-        async fn clear_session(&self) {}
-    }
+    use crate::agent::tests::MockSessionStore;
 
     #[cfg(feature = "default-client")]
     #[tokio::test]
     async fn default() -> Result<()> {
         // default build
         {
-            let agent = BskyAgentBuilder::default().build().await?;
+            let agent = BskyAtpAgentBuilder::default().build().await?;
             assert_eq!(agent.get_endpoint().await, "https://bsky.social");
             assert_eq!(agent.get_session().await, None);
         }
         // with store
         {
-            let agent = BskyAgentBuilder::default().store(MockSessionStore).build().await?;
+            let agent = BskyAtpAgentBuilder::default().store(MockSessionStore).build().await?;
             assert_eq!(agent.get_endpoint().await, "https://bsky.social");
             assert_eq!(
                 agent.get_session().await.map(|session| session.data.handle),
@@ -152,7 +133,7 @@ mod tests {
         }
         // with config
         {
-            let agent = BskyAgentBuilder::default()
+            let agent = BskyAtpAgentBuilder::default()
                 .config(Config {
                     endpoint: "https://example.com".to_string(),
                     ..Default::default()
@@ -172,12 +153,13 @@ mod tests {
 
         // default build
         {
-            let agent = BskyAgentBuilder::new(MockClient).build().await?;
+            let agent = BskyAtpAgentBuilder::new(MockClient).build().await?;
             assert_eq!(agent.get_endpoint().await, "https://bsky.social");
         }
         // with store
         {
-            let agent = BskyAgentBuilder::new(MockClient).store(MockSessionStore).build().await?;
+            let agent =
+                BskyAtpAgentBuilder::new(MockClient).store(MockSessionStore).build().await?;
             assert_eq!(agent.get_endpoint().await, "https://bsky.social");
             assert_eq!(
                 agent.get_session().await.map(|session| session.data.handle),
@@ -186,7 +168,7 @@ mod tests {
         }
         // with config
         {
-            let agent = BskyAgentBuilder::new(MockClient)
+            let agent = BskyAtpAgentBuilder::new(MockClient)
                 .config(Config {
                     endpoint: "https://example.com".to_string(),
                     ..Default::default()

--- a/bsky-sdk/src/agent/config.rs
+++ b/bsky-sdk/src/agent/config.rs
@@ -1,12 +1,11 @@
 //! Configuration for the [`BskyAgent`](super::BskyAgent).
 mod file;
 
-use std::future::Future;
-
+pub use self::file::FileStore;
 use crate::error::{Error, Result};
-use atrium_api::agent::Session;
-pub use file::FileStore;
+use atrium_api::agent::atp_agent::AtpSession;
 use serde::{Deserialize, Serialize};
+use std::future::Future;
 
 /// Configuration data struct for the [`BskyAgent`](super::BskyAgent).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -14,7 +13,7 @@ pub struct Config {
     /// The base URL for the XRPC endpoint.
     pub endpoint: String,
     /// The session data.
-    pub session: Option<Session>,
+    pub session: Option<AtpSession>,
     /// The labelers header values.
     pub labelers_header: Option<Vec<String>>,
     /// The proxy header for service proxying.

--- a/bsky-sdk/src/record.rs
+++ b/bsky-sdk/src/record.rs
@@ -1,22 +1,22 @@
 //! Record operations.
 mod agent;
 
-use std::future::Future;
-
 use crate::error::{Error, Result};
 use crate::BskyAgent;
-use atrium_api::agent::store::SessionStore;
+use atrium_api::agent::atp_agent::store::AtpSessionStore;
 use atrium_api::com::atproto::repo::{
     create_record, delete_record, get_record, list_records, put_record,
 };
 use atrium_api::types::{Collection, LimitedNonZeroU8, TryIntoUnknown};
 use atrium_api::xrpc::XrpcClient;
+use std::future::Future;
 
 #[cfg_attr(not(target_arch = "wasm32"), trait_variant::make(Send))]
 pub trait Record<T, S>
 where
     T: XrpcClient + Send + Sync,
-    S: SessionStore + Send + Sync,
+    S: AtpSessionStore + Send + Sync,
+    S::Error: std::error::Error + Send + Sync + 'static,
 {
     fn list(
         agent: &BskyAgent<T, S>,
@@ -45,7 +45,8 @@ macro_rules! record_impl {
         impl<T, S> Record<T, S> for $record
         where
             T: XrpcClient + Send + Sync,
-            S: SessionStore + Send + Sync,
+            S: AtpSessionStore + Send + Sync,
+            S::Error: std::error::Error + Send + Sync + 'static,
         {
             async fn list(
                 agent: &BskyAgent<T, S>,
@@ -162,7 +163,8 @@ macro_rules! record_impl {
         impl<T, S> Record<T, S> for $record_data
         where
             T: XrpcClient + Send + Sync,
-            S: SessionStore + Send + Sync,
+            S: AtpSessionStore + Send + Sync,
+            S::Error: std::error::Error + Send + Sync + 'static,
         {
             async fn list(
                 agent: &BskyAgent<T, S>,
@@ -278,10 +280,7 @@ record_impl!(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent::BskyAgentBuilder;
-    use crate::tests::FAKE_CID;
-    use atrium_api::agent::Session;
-    use atrium_api::com::atproto::server::create_session::OutputData;
+    use crate::{agent::tests::MockSessionStore, agent::BskyAtpAgentBuilder, tests::FAKE_CID};
     use atrium_api::types::string::Datetime;
     use atrium_api::xrpc::http::{Request, Response};
     use atrium_api::xrpc::types::Header;
@@ -324,33 +323,9 @@ mod tests {
         }
     }
 
-    struct MockSessionStore;
-
-    impl SessionStore for MockSessionStore {
-        async fn get_session(&self) -> Option<Session> {
-            Some(
-                OutputData {
-                    access_jwt: String::from("access"),
-                    active: None,
-                    did: "did:fake:handle.test".parse().expect("invalid did"),
-                    did_doc: None,
-                    email: None,
-                    email_auth_factor: None,
-                    email_confirmed: None,
-                    handle: "handle.test".parse().expect("invalid handle"),
-                    refresh_jwt: String::from("refresh"),
-                    status: None,
-                }
-                .into(),
-            )
-        }
-        async fn set_session(&self, _: Session) {}
-        async fn clear_session(&self) {}
-    }
-
     #[tokio::test]
     async fn actor_profile() -> Result<()> {
-        let agent = BskyAgentBuilder::new(MockClient).store(MockSessionStore).build().await?;
+        let agent = BskyAtpAgentBuilder::new(MockClient).store(MockSessionStore).build().await?;
         // create
         let output = atrium_api::app::bsky::actor::profile::RecordData {
             avatar: None,
@@ -382,7 +357,7 @@ mod tests {
 
     #[tokio::test]
     async fn feed_post() -> Result<()> {
-        let agent = BskyAgentBuilder::new(MockClient).store(MockSessionStore).build().await?;
+        let agent = BskyAtpAgentBuilder::new(MockClient).store(MockSessionStore).build().await?;
         // create
         let output = atrium_api::app::bsky::feed::post::RecordData {
             created_at: Datetime::now(),
@@ -414,7 +389,7 @@ mod tests {
 
     #[tokio::test]
     async fn graph_follow() -> Result<()> {
-        let agent = BskyAgentBuilder::new(MockClient).store(MockSessionStore).build().await?;
+        let agent = BskyAtpAgentBuilder::new(MockClient).store(MockSessionStore).build().await?;
         // create
         let output = atrium_api::app::bsky::graph::follow::RecordData {
             created_at: Datetime::now(),

--- a/bsky-sdk/src/record/agent.rs
+++ b/bsky-sdk/src/record/agent.rs
@@ -1,7 +1,7 @@
 use super::Record;
 use crate::error::{Error, Result};
 use crate::BskyAgent;
-use atrium_api::agent::store::SessionStore;
+use atrium_api::agent::atp_agent::store::AtpSessionStore;
 use atrium_api::com::atproto::repo::{create_record, delete_record};
 use atrium_api::record::KnownRecord;
 use atrium_api::types::string::RecordKey;
@@ -10,7 +10,8 @@ use atrium_api::xrpc::XrpcClient;
 impl<T, S> BskyAgent<T, S>
 where
     T: XrpcClient + Send + Sync,
-    S: SessionStore + Send + Sync,
+    S: AtpSessionStore + Send + Sync,
+    S::Error: std::error::Error + Send + Sync + 'static,
 {
     /// Create a record with various types of data.
     /// For example, the Record families defined in [`KnownRecord`](atrium_api::record::KnownRecord) are supported.

--- a/bsky-sdk/src/rich_text.rs
+++ b/bsky-sdk/src/rich_text.rs
@@ -2,7 +2,7 @@
 mod detection;
 
 use crate::agent::config::Config;
-use crate::agent::BskyAgentBuilder;
+use crate::agent::BskyAtpAgentBuilder;
 use crate::error::Result;
 use atrium_api::app::bsky::richtext::facet::{
     ByteSliceData, Link, MainFeaturesItem, Mention, MentionData, Tag,
@@ -204,7 +204,7 @@ impl RichText {
     }
     /// Detect facets in the text and set them.
     pub async fn detect_facets(&mut self, client: impl XrpcClient + Send + Sync) -> Result<()> {
-        let agent = BskyAgentBuilder::new(client)
+        let agent = BskyAtpAgentBuilder::new(client)
             .config(Config { endpoint: PUBLIC_API_ENDPOINT.into(), ..Default::default() })
             .build()
             .await?;


### PR DESCRIPTION
Extracted from #243 only the parts that are really related to `atrium_api::Agent`.

- Add `SessionManager` trait in preparation for `OAuthSession` addition.
- Add `Agent` struct created from `SessionManager`.
- Move `AtpAgent` as a wrapper for `Agent` created from `CredentialSession`
- `bsky-sdk` was also modified with the above changes.