### PR TITLE
chore: Improve the robustness of the firehose consumer example

### DIFF
--- a/examples/firehose/src/subscription.rs
+++ b/examples/firehose/src/subscription.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 
 #[trait_variant::make(HttpService: Send)]
 pub trait Subscription {
-    async fn next(&mut self) -> Option<Result<Frame, <Frame as TryFrom<&[u8]>>::Error>>;
+    async fn next(&mut self) -> Option<anyhow::Result<Frame>>;
 }
 
 pub trait CommitHandler {


### PR DESCRIPTION
The example previously treated some websocket control frames (e.g. pings) as a signal to exit.

When listening from a low volume PDS, this meant that the example would frequently exit if no activity was occurring.